### PR TITLE
Removed Contacts from Tab TPL App

### DIFF
--- a/TPL/force-app/main/default/applications/Third_Party_Liability_TPL.app-meta.xml
+++ b/TPL/force-app/main/default/applications/Third_Party_Liability_TPL.app-meta.xml
@@ -86,7 +86,6 @@
     <label>Third Party Liability</label>
     <navType>Standard</navType>
     <tabs>standard-Account</tabs>
-    <tabs>standard-Contact</tabs>
     <tabs>standard-Case</tabs>
     <tabs>Batch__c</tabs>
     <tabs>Payment__c</tabs>


### PR DESCRIPTION
Removed contacts tab from the Standard Tabs view list as required by the client