### PR TITLE
Updated TPL Sys Admin PS

### DIFF
--- a/TPL/force-app/main/default/permissionsets/TPL_System_Administrator.permissionset-meta.xml
+++ b/TPL/force-app/main/default/permissionsets/TPL_System_Administrator.permissionset-meta.xml
@@ -873,7 +873,7 @@
         <allowDelete>true</allowDelete>
         <allowEdit>true</allowEdit>
         <allowRead>true</allowRead>
-        <modifyAllRecords>false</modifyAllRecords>
+        <modifyAllRecords>true</modifyAllRecords>
         <object>Account</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>


### PR DESCRIPTION
Updated the TPL System Administrator Permission Set. 

Requirement: TPL System Administrator should be able to delete the Account records. 

In my last #PR276, I added the delete permission but didn't set true to Modify All permission. While performing unit testing it failed.

Updating the security workbook accordingly.