### PR TITLE
Validation Rules

### DIFF
--- a/TPL/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Product_Effective_Year_Check_for_Integra.validationRule-meta.xml
+++ b/TPL/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Product_Effective_Year_Check_for_Integra.validationRule-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Product_Effective_Year_Check_for_Integra</fullName>
+    <active>true</active>
+    <description>This rule will validate the product effective year and the year of adimition.</description>
+    <errorConditionFormula>NOT(Text(year (  Date_of_Admission__c ))  =   Service_Provided_by_Facility__r.Effective_year__c)</errorConditionFormula>
+    <errorMessage>Product effective year does not match with Year of Admission.</errorMessage>
+</ValidationRule>

--- a/TPL/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Service_Type_checks_for_Integration.validationRule-meta.xml
+++ b/TPL/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Service_Type_checks_for_Integration.validationRule-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Service_Type_checks_for_Integration</fullName>
+    <active>true</active>
+    <description>This validation rule will validate</description>
+    <errorConditionFormula>AND (
+Source_System_ID__c &lt;&gt; &quot;&quot;,        
+OR(
+( ISPICKVAL (Service_Provided_by_Facility__r.Service_Type__c , &quot;Acute (Daily)&quot;)  &amp;&amp; Service_Type2__c  &lt;&gt;  &quot;Acute (Daily)&quot;) , 
+( ISPICKVAL (Service_Provided_by_Facility__r.Service_Type__c , &quot;Extended Care (Daily)&quot;)  &amp;&amp; Service_Type2__c  &lt;&gt;  &quot;Extended Care (Daily)&quot; ), 
+( ISPICKVAL (Service_Provided_by_Facility__r.Service_Type__c , &quot;Out Patient (Daily)&quot;)  &amp;&amp; Service_Type2__c  &lt;&gt;  &quot;Out Patient (Daily)&quot; ), 
+( ISPICKVAL (Service_Provided_by_Facility__r.Service_Type__c , &quot;Surgical Day Care (Daily)&quot;)  &amp;&amp; Service_Type2__c  &lt;&gt;  &quot;Surgical Day Care (Daily)&quot; ), 
+( ISPICKVAL (Service_Provided_by_Facility__r.Service_Type__c , &quot;Rehabilitation Care&quot;)  &amp;&amp; Service_Type2__c  &lt;&gt;  &quot;Rehabilitation Care&quot; ) 
+))</errorConditionFormula>
+    <errorMessage>Service Type does not match with selected Service Provided by Facility.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
Created Two Validation rules.
1- For integration records, Service provided by Facility should be selected according to Service Type coming from integration. 
2- Year of Admission should be same as the Service provided by facility effective year.