### PR TITLE
Updated recordTypeId's on flows same as UAT

### DIFF
--- a/TPL/force-app/main/default/flows/New_Ambulance_Record_on_Case.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/New_Ambulance_Record_on_Case.flow-meta.xml
@@ -184,7 +184,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV2AAK</stringValue>
+                <stringValue>012Au000000Bi0yIAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>

--- a/TPL/force-app/main/default/flows/New_Continuing_Care_Record_on_Case.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/New_Continuing_Care_Record_on_Case.flow-meta.xml
@@ -93,7 +93,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV3AAK</stringValue>
+                <stringValue>012Au000000Bi0zIAC</stringValue>
             </value>
         </inputAssignments>
         <object>Healthcare_Cost__c</object>

--- a/TPL/force-app/main/default/flows/New_Future_Care_Record_on_Case.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/New_Future_Care_Record_on_Case.flow-meta.xml
@@ -93,7 +93,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV4AAK</stringValue>
+                <stringValue>012Au000000Bi10IAC</stringValue>
             </value>
         </inputAssignments>
         <object>Healthcare_Cost__c</object>

--- a/TPL/force-app/main/default/flows/New_Hospitalization_Record_on_Case.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/New_Hospitalization_Record_on_Case.flow-meta.xml
@@ -348,7 +348,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV5AAK</stringValue>
+                <stringValue>012Au000000Bi11IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -449,7 +449,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV5AAK</stringValue>
+                <stringValue>012Au000000Bi11IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -550,7 +550,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV5AAK</stringValue>
+                <stringValue>012Au000000Bi11IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -651,7 +651,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV5AAK</stringValue>
+                <stringValue>012Au000000Bi11IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -752,7 +752,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV5AAK</stringValue>
+                <stringValue>012Au000000Bi11IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -853,7 +853,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV5AAK</stringValue>
+                <stringValue>012Au000000Bi11IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -913,7 +913,7 @@
             <field>RecordTypeId</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>0126s000000CtUzAAK</stringValue>
+                <stringValue>012Au000000Bi0vIAC</stringValue>
             </value>
         </filters>
         <getFirstRecordOnly>true</getFirstRecordOnly>
@@ -941,7 +941,7 @@
             <field>RecordTypeId</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>0126s000000CtUzAAK</stringValue>
+                <stringValue>012Au000000Bi0vIAC</stringValue>
             </value>
         </filters>
         <getFirstRecordOnly>true</getFirstRecordOnly>

--- a/TPL/force-app/main/default/flows/New_MSP_Record.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/New_MSP_Record.flow-meta.xml
@@ -343,7 +343,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV6AAK</stringValue>
+                <stringValue>012Au000000Bi12IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>

--- a/TPL/force-app/main/default/flows/New_Pharmacare_Record.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/New_Pharmacare_Record.flow-meta.xml
@@ -185,7 +185,7 @@
         <inputAssignments>
             <field>RecordTypeId</field>
             <value>
-                <stringValue>0126s000000CtV7AAK</stringValue>
+                <stringValue>012Au000000Bi13IAC</stringValue>
             </value>
         </inputAssignments>
         <inputAssignments>

--- a/TPL/force-app/main/default/flows/Populate_Site_code_Facility_Service_Type_for_Hospitalization_Records.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/Populate_Site_code_Facility_Service_Type_for_Hospitalization_Records.flow-meta.xml
@@ -216,7 +216,7 @@
             <field>RecordTypeId</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>0126s000000CtUzAAK</stringValue>
+                <stringValue>012Au000000Bi0vIAC</stringValue>
             </value>
         </filters>
         <getFirstRecordOnly>false</getFirstRecordOnly>

--- a/TPL/force-app/main/default/flows/Populate_site_code_and_Facility_on_Ambulance_Record.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/Populate_site_code_and_Facility_on_Ambulance_Record.flow-meta.xml
@@ -216,7 +216,7 @@
             <field>RecordTypeId</field>
             <operator>EqualTo</operator>
             <value>
-                <stringValue>0126s000000CtUzAAK</stringValue>
+                <stringValue>012Au000000Bi0vIAC</stringValue>
             </value>
         </filters>
         <getFirstRecordOnly>false</getFirstRecordOnly>


### PR DESCRIPTION
1. The recordTypeId's are different on each Hyperforce environments. This needs to be performed as a Post-Deployment Steps on 
QAA and other Dev Org's except UAT. 
2. The recordTypeId's on the flows are now same as UAT (This will be part of the package and no post-deployment step is needed on UAT)