### PR TITLE
Sort Order Implementation for Case Level Grids

### DIFF
--- a/TPL/force-app/main/default/classes/HCCostCaseController.cls
+++ b/TPL/force-app/main/default/classes/HCCostCaseController.cls
@@ -25,7 +25,7 @@ public with sharing class HCCostCaseController {
     }
 
     @AuraEnabled
-    public static HCCostCaseDetailWrapper getHealthcareCostsAmbulanceForCase(String caseId, String filterValue, Integer pageSize, Integer pageNumber){
+    public static HCCostCaseDetailWrapper getHealthcareCostsAmbulanceForCase(String caseId, String filterValue, Integer pageSize, Integer pageNumber, String sortOrder){
         List<Healthcare_Cost__c> hccCostList = new List<Healthcare_Cost__c> ();
         HCCostCaseDetailWrapper caseDetailWrapper = new HCCostCaseDetailWrapper();
         String sourceSystemId = null;
@@ -36,7 +36,7 @@ public with sharing class HCCostCaseController {
             Id recordTypeId = HCCostRecordTypeIds.getAmbulanceRecordId();
             totalCount = HCCostCaseController.getHCCostCountonCase(caseId, filterValue, recordTypeId);
             startItemNumber = HCCostCaseController.getStartNumber(pageSize, pageNumber, totalCount);
-            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, ambulanceFields);
+            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, ambulanceFields, sortOrder);
             caseDetailWrapper.hccList = hccCostList;
             caseDetailWrapper.totalCount = totalCount;
         } catch(NullPointerException nullpointer){
@@ -49,7 +49,7 @@ public with sharing class HCCostCaseController {
     }
 
     @AuraEnabled
-    public static HCCostCaseDetailWrapper getHealthcareCostsPharmacareForCase(String caseId, String filterValue, Integer pageSize, Integer pageNumber){
+    public static HCCostCaseDetailWrapper getHealthcareCostsPharmacareForCase(String caseId, String filterValue, Integer pageSize, Integer pageNumber, String sortOrder){
         List<Healthcare_Cost__c> hccCostList = new List<Healthcare_Cost__c> ();
         HCCostCaseDetailWrapper caseDetailWrapper = new HCCostCaseDetailWrapper();
         String sourceSystemId = null;
@@ -60,7 +60,7 @@ public with sharing class HCCostCaseController {
             Id recordTypeId = HCCostRecordTypeIds.getPharmacareRecordId();
             totalCount = HCCostCaseController.getHCCostCountonCase(caseId, filterValue, recordTypeId);
             startItemNumber = HCCostCaseController.getStartNumber(pageSize, pageNumber, totalCount);
-            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, pharmacareFields);
+            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, pharmacareFields,sortOrder);
             caseDetailWrapper.hccList = hccCostList;
             caseDetailWrapper.totalCount = totalCount;
         } catch(NullPointerException nullpointer){
@@ -73,7 +73,7 @@ public with sharing class HCCostCaseController {
     }
 
     @AuraEnabled
-    public static HCCostCaseDetailWrapper getHealthcareCostsMSPForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize)
+    public static HCCostCaseDetailWrapper getHealthcareCostsMSPForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize, String sortOrder)
     { 
         List<Healthcare_Cost__c> hccCostList = new List<Healthcare_Cost__c> ();
         HCCostCaseDetailWrapper caseDetailWrapper = new HCCostCaseDetailWrapper();
@@ -85,7 +85,7 @@ public with sharing class HCCostCaseController {
             Id recordTypeId = HCCostRecordTypeIds.getMSPRecordId();
             totalCount = HCCostCaseController.getHCCostCountonCase(caseId, filterValue, recordTypeId);
             startItemNumber = HCCostCaseController.getStartNumber(pageSize, pageNumber, totalCount);
-            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, mspFields);
+            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, mspFields, sortOrder);
             caseDetailWrapper.hccList = hccCostList;
             caseDetailWrapper.totalCount = totalCount;
         } catch(NullPointerException nullpointer){
@@ -98,7 +98,7 @@ public with sharing class HCCostCaseController {
     }
 
     @AuraEnabled
-    public static HCCostCaseDetailWrapper getHealthcareCostsHospitalForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize){
+    public static HCCostCaseDetailWrapper getHealthcareCostsHospitalForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize, String sortOrder){
         List<Healthcare_Cost__c> hccCostList = new List<Healthcare_Cost__c> ();
         HCCostCaseDetailWrapper caseDetailWrapper = new HCCostCaseDetailWrapper();
         String sourceSystemId = null;
@@ -109,7 +109,7 @@ public with sharing class HCCostCaseController {
             Id recordTypeId = HCCostRecordTypeIds.getHospitalRecordId();
             totalCount = HCCostCaseController.getHCCostCountonCase(caseId, filterValue, recordTypeId);
             startItemNumber = HCCostCaseController.getStartNumber(pageSize, pageNumber, totalCount);
-            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, hospitalFields);
+            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, hospitalFields, sortOrder);
             caseDetailWrapper.hccList = hccCostList;
             caseDetailWrapper.totalCount = totalCount;
         } catch(NullPointerException nullpointer){
@@ -122,7 +122,7 @@ public with sharing class HCCostCaseController {
     }
 
     @AuraEnabled
-    public static HCCostCaseDetailWrapper getHealthcareCostsCCForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize){
+    public static HCCostCaseDetailWrapper getHealthcareCostsCCForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize, String sortOrder){
         List<Healthcare_Cost__c> hccCostList = new List<Healthcare_Cost__c> ();
         HCCostCaseDetailWrapper caseDetailWrapper = new HCCostCaseDetailWrapper();
         Integer totalCount = 0;
@@ -132,7 +132,7 @@ public with sharing class HCCostCaseController {
             Id recordTypeId = HCCostRecordTypeIds.getContinuingCareRecordId();
             totalCount = HCCostCaseController.getHCCostCountonCase(caseId, filterValue, recordTypeId);
             startItemNumber = HCCostCaseController.getStartNumber(pageSize, pageNumber, totalCount);
-            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, countinuingCareFields);
+            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, countinuingCareFields, sortOrder);
             caseDetailWrapper.hccList = hccCostList;
             caseDetailWrapper.totalCount = totalCount;
         } catch(NullPointerException nullpointer){
@@ -146,7 +146,7 @@ public with sharing class HCCostCaseController {
 
      
     @AuraEnabled
-    public static HCCostCaseDetailWrapper getHealthcareCostsFCForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize){
+    public static HCCostCaseDetailWrapper getHealthcareCostsFCForCase(String caseId, String filterValue, Integer pageNumber, Integer pageSize, String sortOrder){
         List<Healthcare_Cost__c> hccCostList = new List<Healthcare_Cost__c> ();
         HCCostCaseDetailWrapper caseDetailWrapper = new HCCostCaseDetailWrapper();
         Integer totalCount = 0;
@@ -156,7 +156,7 @@ public with sharing class HCCostCaseController {
             Id recordTypeId = HCCostRecordTypeIds.getFutureCareRecordId();
             totalCount = HCCostCaseController.getHCCostCountonCase(caseId, filterValue, recordTypeId);
             startItemNumber = HCCostCaseController.getStartNumber(pageSize, pageNumber, totalCount);
-            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, futureCareFields);
+            hccCostList = HCCostCaseDAO.getHCCostCaseRecords(caseId, filterValue, recordTypeId, startItemNumber, pageSize, futureCareFields, sortOrder);
             caseDetailWrapper.hccList = hccCostList;
             caseDetailWrapper.totalCount = totalCount;
         } catch(NullPointerException nullpointer){

--- a/TPL/force-app/main/default/classes/HCCostCaseControllerTest.cls
+++ b/TPL/force-app/main/default/classes/HCCostCaseControllerTest.cls
@@ -1,7 +1,7 @@
 @isTest
 public with sharing class HCCostCaseControllerTest {
     @isTest
-    static void testGetHealthcareCostsAmbulanceForCase(){
+    static void testGetHealthcareCostsAmbulanceForCaseDescendingSort(){
         Account acc = TestDataFactory.individualAccount();
         insert acc;
         Case c = TestDataFactory.newCase(acc.Id);
@@ -24,15 +24,16 @@ public with sharing class HCCostCaseControllerTest {
         String filterRecordsToday = Label.TPL_Records_Created_Today;
         Integer pageNumber = 2;
         Integer pageSize = 5;
+        String sortOrder = Label.TPL_Descending;
         String exceptionMessage = null;
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
         try{
             insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3, hcc4, hcc5, hcc6, hcc7, hcc8, hcc9, hcc10, hcc11};
-            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterAllRecords,pageSize, pageNumber);
-            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterManualRecords,pageSize, pageNumber);
-            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterRecordsToday,pageSize, pageNumber);    
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterAllRecords,pageSize, pageNumber,sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterManualRecords,pageSize, pageNumber,sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterRecordsToday,pageSize, pageNumber,sortOrder);    
         }
         catch(DmlException dml){
             exceptionMessage = dml.getMessage();
@@ -47,7 +48,54 @@ public with sharing class HCCostCaseControllerTest {
     }
 
     @isTest
-    static void testGetHealthcareCostsHospitalForCase(){
+    static void testGetHealthcareCostsAmbulanceForCaseAscendingSort(){
+        Account acc = TestDataFactory.individualAccount();
+        insert acc;
+        Case c = TestDataFactory.newCase(acc.Id);
+        insert c;
+		Healthcare_Cost__c hcc1 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc2 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc3 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc4 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc5 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc6 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc7 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc8 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc9 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc10 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc11 = TestDataFactory.ambulanceCostRecord(acc.Id, c.Id);
+            
+        Test.startTest();
+        String filterAllRecords = Label.TPL_All_Records;
+        String filterManualRecords = Label.TPL_Manual_Records;
+        String filterRecordsToday = Label.TPL_Records_Created_Today;
+        Integer pageNumber = 2;
+        Integer pageSize = 5;
+        String sortOrder = Label.TPL_Ascending;
+        String exceptionMessage = null;
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        try{
+            insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3, hcc4, hcc5, hcc6, hcc7, hcc8, hcc9, hcc10, hcc11};
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterAllRecords,pageSize, pageNumber,sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterManualRecords,pageSize, pageNumber,sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsAmbulanceForCase(c.Id,filterRecordsToday,pageSize, pageNumber,sortOrder);    
+        }
+        catch(DmlException dml){
+            exceptionMessage = dml.getMessage();
+        }
+        Test.stopTest();
+        if(exceptionMessage != null){
+            System.assertNotEquals(null, exceptionMessage);
+        }
+        else {
+            System.assertEquals(caseDetailWrapper2.hccList.size(),caseDetailWrapper3.hccList.size());            
+        }
+    }
+
+    @isTest
+    static void testGetHealthcareCostsHospitalForCaseDescendingSort(){
         Account acc = TestDataFactory.individualAccount();
         insert acc;
         Account facility = TestDataFactory.facilityAccount();
@@ -62,6 +110,7 @@ public with sharing class HCCostCaseControllerTest {
         String filterRecordsToday = Label.TPL_Records_Created_Today;
         Integer pageNumber = 1;
         Integer pageSize = 5;
+        String sortOrder = Label.TPL_Descending;
         String exceptionMessage = null;
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
@@ -73,9 +122,9 @@ public with sharing class HCCostCaseControllerTest {
             Healthcare_Cost__c hcc2 = TestDataFactory.hospitalizationCostRecord(acc.Id, c.Id, facility.Id, pr.Id, serviceType);
             Healthcare_Cost__c hcc3 = TestDataFactory.hospitalizationCostRecord(acc.Id, c.Id, facility.Id, pr.Id, serviceType);
             insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3};
-            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterAllRecords,pageSize, pageNumber);
-            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterManualRecords,pageSize, pageNumber);
-            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterRecordsToday,pageSize, pageNumber);    
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterAllRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
         }
         catch(DmlException dml){
             exceptionMessage = dml.getMessage();
@@ -90,7 +139,51 @@ public with sharing class HCCostCaseControllerTest {
     }
 
     @isTest
-    static void testGetHealthcareCostsMSPForCase(){
+    static void testGetHealthcareCostsHospitalForCaseAscendingSort(){
+        Account acc = TestDataFactory.individualAccount();
+        insert acc;
+        Account facility = TestDataFactory.facilityAccount();
+        insert facility;
+        Case c = TestDataFactory.newCase(acc.Id);
+        insert c;
+        Product2 pr = TestDataFactory.newProduct(facility.Id);
+        String serviceType = pr.Service_Type__c;
+        Test.startTest();
+        String filterAllRecords = Label.TPL_All_Records;
+        String filterManualRecords = Label.TPL_Manual_Records;
+        String filterRecordsToday = Label.TPL_Records_Created_Today;
+        Integer pageNumber = 1;
+        Integer pageSize = 5;
+        String sortOrder = Label.TPL_Ascending;
+        String exceptionMessage = null;
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
+
+        try{
+            insert pr;
+            Healthcare_Cost__c hcc1 = TestDataFactory.hospitalizationCostRecord(acc.Id, c.Id, facility.Id, pr.Id, serviceType);
+            Healthcare_Cost__c hcc2 = TestDataFactory.hospitalizationCostRecord(acc.Id, c.Id, facility.Id, pr.Id, serviceType);
+            Healthcare_Cost__c hcc3 = TestDataFactory.hospitalizationCostRecord(acc.Id, c.Id, facility.Id, pr.Id, serviceType);
+            insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3};
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterAllRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsHospitalForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
+        }
+        catch(DmlException dml){
+            exceptionMessage = dml.getMessage();
+        }
+        Test.stopTest();
+        if(exceptionMessage != null){
+            System.assertNotEquals(null, exceptionMessage);
+        }
+        else {
+            System.assertEquals(caseDetailWrapper2.hccList.size(),caseDetailWrapper3.hccList.size());            
+        }
+    }
+
+    @isTest
+    static void testGetHealthcareCostsMSPForCaseDescendingSort(){
         Account acc = TestDataFactory.individualAccount();
         insert acc;
         Case c = TestDataFactory.newCase(acc.Id);
@@ -105,15 +198,16 @@ public with sharing class HCCostCaseControllerTest {
         String filterRecordsToday = Label.TPL_Records_Created_Today;
         Integer pageNumber = 1;
         Integer pageSize = 5;
+        String sortOrder = Label.TPL_Descending;
         String exceptionMessage = null;
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
         try{
             insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3};
-            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterAllRecords,pageSize, pageNumber);
-            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterManualRecords,pageSize, pageNumber);
-            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterRecordsToday,pageSize, pageNumber);    
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterAllRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
         }
         catch(DmlException dml){
             exceptionMessage = dml.getMessage();
@@ -128,7 +222,46 @@ public with sharing class HCCostCaseControllerTest {
     }
 
     @isTest
-    static void testGetHealthcareCostsPharmacareForCase(){
+    static void testGetHealthcareCostsMSPForCaseAscendingSort(){
+        Account acc = TestDataFactory.individualAccount();
+        insert acc;
+        Case c = TestDataFactory.newCase(acc.Id);
+        insert c;
+		Healthcare_Cost__c hcc1 = TestDataFactory.mspCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc2 = TestDataFactory.mspCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc3 = TestDataFactory.mspCostRecord(acc.Id, c.Id);
+      
+        Test.startTest();
+        String filterAllRecords = Label.TPL_All_Records;
+        String filterManualRecords = Label.TPL_Manual_Records;
+        String filterRecordsToday = Label.TPL_Records_Created_Today;
+        Integer pageNumber = 1;
+        Integer pageSize = 5;
+        String sortOrder = Label.TPL_Ascending;
+        String exceptionMessage = null;
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        try{
+            insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3};
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterAllRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsMSPForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
+        }
+        catch(DmlException dml){
+            exceptionMessage = dml.getMessage();
+        }
+        Test.stopTest();
+        if(exceptionMessage != null){
+            System.assertNotEquals(null, exceptionMessage);
+        }
+        else {
+            System.assertEquals(caseDetailWrapper2.hccList.size(),caseDetailWrapper3.hccList.size());            
+        }
+    }
+
+    @isTest
+    static void testGetHealthcareCostsPharmacareForCaseDescendingSort(){
         Account acc = TestDataFactory.individualAccount();
         insert acc;
         Case c = TestDataFactory.newCase(acc.Id);
@@ -151,15 +284,63 @@ public with sharing class HCCostCaseControllerTest {
         String filterRecordsToday = Label.TPL_Records_Created_Today;
         Integer pageNumber = 1;
         Integer pageSize = 5;
+        String sortOrder = Label.TPL_Descending;
         String exceptionMessage = null;
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
         try{
             insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3, hcc4, hcc5, hcc6, hcc7, hcc8, hcc9, hcc10, hcc11};
-            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterAllRecords,pageSize, pageNumber);
-            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterManualRecords,pageSize, pageNumber);
-            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterRecordsToday,pageSize, pageNumber);    
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterAllRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
+        }
+        catch(DmlException dml){
+            exceptionMessage = dml.getMessage();
+        }
+        Test.stopTest();
+        if(exceptionMessage != null){
+            System.assertNotEquals(null, exceptionMessage);
+        }
+        else {
+            System.assertEquals(caseDetailWrapper2.hccList.size(),caseDetailWrapper3.hccList.size());            
+        }
+    }
+
+    @isTest
+    static void testGetHealthcareCostsPharmacareForCaseAscendingSort(){
+        Account acc = TestDataFactory.individualAccount();
+        insert acc;
+        Case c = TestDataFactory.newCase(acc.Id);
+        insert c;
+		Healthcare_Cost__c hcc1 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc2 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc3 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc4 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc5 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc6 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc7 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc8 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc9 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc10 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+        Healthcare_Cost__c hcc11 = TestDataFactory.pharmacareCostRecord(acc.Id, c.Id);
+            
+        Test.startTest();
+        String filterAllRecords = Label.TPL_All_Records;
+        String filterManualRecords = Label.TPL_Manual_Records;
+        String filterRecordsToday = Label.TPL_Records_Created_Today;
+        Integer pageNumber = 1;
+        Integer pageSize = 5;
+        String sortOrder = Label.TPL_Ascending;
+        String exceptionMessage = null;
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper3 = new HCCostCaseController.HCCostCaseDetailWrapper();
+        try{
+            insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3, hcc4, hcc5, hcc6, hcc7, hcc8, hcc9, hcc10, hcc11};
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterAllRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper3 = HCCostCaseController.getHealthcareCostsPharmacareForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
         }
         catch(DmlException dml){
             exceptionMessage = dml.getMessage();
@@ -187,14 +368,15 @@ public with sharing class HCCostCaseControllerTest {
         String filterManualRecords = Label.TPL_Manual_Records;
         String filterRecordsToday = Label.TPL_Records_Created_Today;
         Integer pageNumber = 1;
+        String sortOrder = Label.TPL_Descending;
         Integer pageSize = 5;
         String exceptionMessage = null;
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper2 = new HCCostCaseController.HCCostCaseDetailWrapper();
         try{
             insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3};
-            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsCCForCase(c.Id,filterManualRecords,pageSize, pageNumber);
-            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsCCForCase(c.Id,filterRecordsToday,pageSize, pageNumber);    
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsCCForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsCCForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
         }
         catch(DmlException dml){
             exceptionMessage = dml.getMessage();
@@ -223,6 +405,7 @@ public with sharing class HCCostCaseControllerTest {
         String filterManualRecords = Label.TPL_Manual_Records;
         String filterRecordsToday = Label.TPL_Records_Created_Today;
         Integer pageNumber = 1;
+        String sortOrder = Label.TPL_Descending;
         Integer pageSize = 5;
         String exceptionMessage = null;
         HCCostCaseController.HCCostCaseDetailWrapper caseDetailWrapper1 = new HCCostCaseController.HCCostCaseDetailWrapper();
@@ -230,8 +413,8 @@ public with sharing class HCCostCaseControllerTest {
       
         try{
             insert new Healthcare_Cost__c[] {hcc1, hcc2, hcc3};
-            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsFCForCase(c.Id,filterManualRecords,pageSize, pageNumber);
-            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsFCForCase(c.Id,filterRecordsToday,pageSize, pageNumber);    
+            caseDetailWrapper1 = HCCostCaseController.getHealthcareCostsFCForCase(c.Id,filterManualRecords,pageSize, pageNumber, sortOrder);
+            caseDetailWrapper2 = HCCostCaseController.getHealthcareCostsFCForCase(c.Id,filterRecordsToday,pageSize, pageNumber, sortOrder);    
         }
         catch(DmlException dml){
             exceptionMessage = dml.getMessage();

--- a/TPL/force-app/main/default/classes/HCCostCaseDAO.cls
+++ b/TPL/force-app/main/default/classes/HCCostCaseDAO.cls
@@ -1,83 +1,187 @@
 public with sharing class HCCostCaseDAO {
-    public static List<Healthcare_Cost__c> getHCCostCaseRecords(String caseId, String filterValue, Id recordTypeId, Integer startItemNumber, Integer pageSize, String fields){
-        Integer itemsToRemove = startItemNumber - 2;
-        System.debug(itemsToRemove);
-        list<Healthcare_Cost__c> hccList = new list<Healthcare_Cost__c>();
-        String dateId = '';
-        String query = '';
-        String sourceSystemId = null;
-        Boolean costValue = false;
-        try{
-           
-            if(filterValue == Label.TPL_Manual_Records){
-                if(itemsToRemove > 2000)
+public static List<Healthcare_Cost__c> getHCCostCaseRecords(String caseId, String filterValue, Id recordTypeId, Integer startItemNumber, Integer pageSize, String fields, String sortOrder){
+Integer itemsToRemove = startItemNumber - 2;
+System.debug(itemsToRemove);
+list<Healthcare_Cost__c> hccList = new list<Healthcare_Cost__c>();
+String dateId = '';
+String query = '';
+String sourceSystemId = null;
+Boolean costValue = false;
+try{
+    if(sortOrder == null || sortOrder == ''){
+        sortOrder = 'asc';
+    }
+    System.debug('sortOrder : ' + sortOrder);
+    if(sortOrder == Label.TPL_Descending){
+    // Populate DateID to maximum value
+        dateId = '99999999zz';
+        if(filterValue == Label.TPL_Manual_Records){
+            
+            if(itemsToRemove > 2000)
+            {
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c 
+                WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId 
+                ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
+                itemsToRemove -= 2001;
+                while( itemsToRemove > 2000 )
                 {
-                    dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId and Source_System_ID__c = :sourceSystemId ORDER BY dateId__c LIMIT 1 OFFSET 2000][0].dateId__c;
+                    dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId  AND Source_System_ID__c = :sourceSystemId AND dateId__c < :dateId ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
                     itemsToRemove -= 2001;
-                    while( itemsToRemove > 2000 )
-                    {
-                        dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId  and Source_System_ID__c = :sourceSystemId and dateId__c > :dateId order by dateId__c LIMIT 1 OFFSET 2000][0].dateId__c;
-                        itemsToRemove -= 2001;
-                    }
                 }
-                if(itemsToRemove > 0){
-                    dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId  and Source_System_ID__c = :sourceSystemId and dateId__c > :dateId ORDER BY dateId__c LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
-                    itemsToRemove = 0;
-                }
-               
-                query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = :caseId and RecordTypeId = :recordTypeId and Source_System_ID__c = :sourceSystemId and dateId__c > :dateId order by dateId__c LIMIT :pageSize';
-                hccList = Database.query(query);
-         
+                System.debug('Items to remove : ' + itemsToRemove);
             }
-            else if(filterValue == Label.TPL_Records_Created_Today) {
-                if(itemsToRemove > 2000)
-                {
-                    dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId and Source_System_ID__c = :sourceSystemId and CreatedDate = TODAY  ORDER BY dateId__c LIMIT 1 OFFSET 2000][0].dateId__c;
-                    itemsToRemove -= 2001;
-                    while( itemsToRemove > 2000 )
-                    {
-                        dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId and Source_System_ID__c = :sourceSystemId and CreatedDate = TODAY  and dateId__c > :dateId order by dateId__c LIMIT 1 OFFSET 2000][0].dateId__c;
-                        itemsToRemove -= 2001;
-                    }
-                }
-                if(itemsToRemove > 0){
-                    dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId and Source_System_ID__c = :sourceSystemId and CreatedDate = TODAY  and dateId__c > :dateId ORDER BY dateId__c LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
-                    itemsToRemove = 0;
-                }
-                query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = :caseId and RecordTypeId = :recordTypeId and Source_System_ID__c = :sourceSystemId and CreatedDate = TODAY and dateId__c > :dateId order by dateId__c LIMIT :pageSize';
-                hccList = Database.query(query);
-         
+            
+            if(itemsToRemove > 0){
+                
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c 
+                WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId  AND Source_System_ID__c = :sourceSystemId AND dateId__c < :dateId 
+                ORDER BY dateId__c DESC LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
+                itemsToRemove = 0;
             }
-            else {
-                if(itemsToRemove > 2000)
+
+            query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId + '\' AND RecordTypeId = \'' 
+            + recordTypeId +'\' AND Source_System_ID__c = ' + sourceSystemId + ' AND dateId__c < \'' + dateId 
+            + '\' ORDER BY dateId__c DESC LIMIT ' + pageSize;
+            System.debug('Query : ' + query);
+            hccList = Database.query(query);
+            System.debug('List Size ' + hccList.size());
+        }
+
+    else if(filterValue == Label.TPL_Records_Created_Today) {
+        if(itemsToRemove > 2000)
+        {
+        dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId AND CreatedDate = TODAY ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
+            itemsToRemove -= 2001;
+            while( itemsToRemove > 2000 )
+            {
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId AND CreatedDate = TODAY  AND dateId__c < :dateId ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
+                itemsToRemove -= 2001;
+            }
+        }
+
+        if(itemsToRemove > 0){
+            dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId AND CreatedDate = TODAY  AND dateId__c < :dateId ORDER BY dateId__c DESC LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
+            itemsToRemove = 0;
+        }
+        
+        query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \''+ caseId + '\' AND RecordTypeId = \'' 
+        + recordTypeId +'\' AND Source_System_ID__c = ' + sourceSystemId +' AND CreatedDate = TODAY AND dateId__c < \''+ dateId 
+        +'\' ORDER BY dateId__c DESC LIMIT '+ pageSize;
+        System.debug('Query : ' + query);
+        hccList = Database.query(query);
+
+    }
+
+        else {
+            if(itemsToRemove > 2000)
+            {
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
+                itemsToRemove -= 2001;
+                while( itemsToRemove > 2000 )
                 {
-                    dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId ORDER BY dateId__c LIMIT 1 OFFSET 2000][0].dateId__c;
+                    dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND dateId__c < :dateId ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
                     itemsToRemove -= 2001;
-                    while( itemsToRemove > 2000 )
-                    {
-                        dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId and dateId__c > :dateId order by dateId__c LIMIT 1 OFFSET 2000][0].dateId__c;
-                        itemsToRemove -= 2001;
-                    }
                 }
-                if(itemsToRemove > 0){
-                    dateId = [select dateId__c from Healthcare_Cost__c where Case2__c = :caseId and RecordTypeId = :recordTypeId and dateId__c > :dateId ORDER BY dateId__c LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
-                    itemsToRemove = 0;
-                }
-                query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = :caseId and RecordTypeId = :recordTypeId and dateId__c > :dateId order by dateId__c LIMIT :pageSize';
-                hccList = Database.query(query);
+            }
+            if(itemsToRemove > 0){
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND dateId__c < :dateId ORDER BY dateId__c DESC LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
+                itemsToRemove = 0;
             }
     
+            query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId + '\' AND RecordTypeId = \'' 
+            + recordTypeId + '\' AND dateId__c < \'' + dateId +'\' ORDER BY dateId__c DESC LIMIT ' + pageSize;
+            System.debug('Query : ' + query);
+            hccList = Database.query(query);
         }
-        catch(LimitException l){
-            System.debug(l.getMessage());
+        System.debug('Start Item Number : ' + startItemNumber + ', Items to remove : ' + itemsToRemove +', Page Size : ' + pageSize +', List Size : ' + hccList.size());
+    }
+    
+    else
+    {
+        if(filterValue == Label.TPL_Manual_Records){
+            if(itemsToRemove > 2000)
+            {
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId ORDER BY dateId__c ASC LIMIT 1 OFFSET 2000][0].dateId__c;
+                itemsToRemove -= 2001;
+                while( itemsToRemove > 2000 )
+                {
+                    dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId  AND Source_System_ID__c = :sourceSystemId AND dateId__c > :dateId ORDER BY dateId__c ASC LIMIT 1 OFFSET 2000][0].dateId__c;
+                    itemsToRemove -= 2001;
+                }
+            }
+            if(itemsToRemove > 0){
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId  AND Source_System_ID__c = :sourceSystemId AND dateId__c > :dateId ORDER BY dateId__c ASC LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
+                itemsToRemove = 0;
+            }
+        
+            query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \''+caseId + '\' AND RecordTypeId = \''
+            + recordTypeId + '\' AND Source_System_ID__c = '+ sourceSystemId +' AND dateId__c > \'' + dateId + '\' ORDER BY dateId__c ASC LIMIT '+ pageSize;
+            System.debug('Query : ' + query);
+            hccList = Database.query(query);
+            
         }
-        catch(ListException listexception){
-            System.debug(listexception.getMessage());
+    
+        else if(filterValue == Label.TPL_Records_Created_Today) {
+            if(itemsToRemove > 2000)
+            {
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId AND CreatedDate = TODAY  ORDER BY dateId__c ASC LIMIT 1 OFFSET 2000][0].dateId__c;
+                itemsToRemove -= 2001;
+                while( itemsToRemove > 2000 )
+                {
+                    dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId AND CreatedDate = TODAY  AND dateId__c > :dateId ORDER BY dateId__c ASC LIMIT 1 OFFSET 2000][0].dateId__c;
+                    itemsToRemove -= 2001;
+                }
+            }
+        
+            if(itemsToRemove > 0){
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND Source_System_ID__c = :sourceSystemId AND CreatedDate = TODAY  AND dateId__c > :dateId ORDER BY dateId__c ASC LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
+                itemsToRemove = 0;
+            }
+            
+            query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId +'\' AND RecordTypeId = \'' 
+            + recordTypeId +'\' AND Source_System_ID__c = ' + sourceSystemId + ' AND CreatedDate = TODAY AND dateId__c > \'' + dateId 
+            +'\' ORDER BY dateId__c ASC LIMIT ' + pageSize;
+            System.debug('Query : ' + query);
+            hccList = Database.query(query);
+    
         }
-        catch(DmlException dml){
-            System.debug(dml.getMessage());
+    
+        else {
+            if(itemsToRemove > 2000)
+            {
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId ORDER BY dateId__c ASC LIMIT 1 OFFSET 2000][0].dateId__c;
+                itemsToRemove -= 2001;
+                while( itemsToRemove > 2000 )
+                {
+                    dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND dateId__c > :dateId ORDER BY dateId__c ASC LIMIT 1 OFFSET 2000][0].dateId__c;
+                    itemsToRemove -= 2001;
+                }
+            }
+            if(itemsToRemove > 0){
+                dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId AND dateId__c > :dateId ORDER BY dateId__c ASC LIMIT 1 OFFSET :itemsToRemove][0].dateId__c;
+                itemsToRemove = 0;
+            }
+        
+            query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId + '\' AND RecordTypeId = \''
+            + recordTypeId + '\' AND dateId__c > \'' + dateId + '\' ORDER BY dateId__c ASC LIMIT ' + pageSize;
+            System.debug('Query : ' + query);
+            hccList = Database.query(query);
         }
-       
-        return hccList;
-   }
+        System.debug('Start Item Number : ' + startItemNumber + ', Items to remove : ' + itemsToRemove +', Page Size : ' + pageSize +', List Size : ' + hccList.size());
+    }
+
+    
+}
+catch(LimitException l){
+    System.debug(l.getMessage());
+}
+catch(ListException listexception){
+    System.debug(listexception.getMessage());
+}
+catch(DmlException dml){
+    System.debug(dml.getMessage());
+}
+
+return hccList;
+}
 }

--- a/TPL/force-app/main/default/classes/HCCostCaseDAO.cls
+++ b/TPL/force-app/main/default/classes/HCCostCaseDAO.cls
@@ -1,7 +1,7 @@
 public with sharing class HCCostCaseDAO {
 public static List<Healthcare_Cost__c> getHCCostCaseRecords(String caseId, String filterValue, Id recordTypeId, Integer startItemNumber, Integer pageSize, String fields, String sortOrder){
 Integer itemsToRemove = startItemNumber - 2;
-System.debug(itemsToRemove);
+
 list<Healthcare_Cost__c> hccList = new list<Healthcare_Cost__c>();
 String dateId = '';
 String query = '';
@@ -11,7 +11,7 @@ try{
     if(sortOrder == null || sortOrder == ''){
         sortOrder = 'asc';
     }
-    System.debug('sortOrder : ' + sortOrder);
+
     if(sortOrder == Label.TPL_Descending){
     // Populate DateID to maximum value
         dateId = '99999999zz';
@@ -28,7 +28,7 @@ try{
                     dateId = [SELECT dateId__c FROM Healthcare_Cost__c WHERE Case2__c = :caseId AND RecordTypeId = :recordTypeId  AND Source_System_ID__c = :sourceSystemId AND dateId__c < :dateId ORDER BY dateId__c DESC LIMIT 1 OFFSET 2000][0].dateId__c;
                     itemsToRemove -= 2001;
                 }
-                System.debug('Items to remove : ' + itemsToRemove);
+               
             }
             
             if(itemsToRemove > 0){
@@ -42,9 +42,9 @@ try{
             query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId + '\' AND RecordTypeId = \'' 
             + recordTypeId +'\' AND Source_System_ID__c = ' + sourceSystemId + ' AND dateId__c < \'' + dateId 
             + '\' ORDER BY dateId__c DESC LIMIT ' + pageSize;
-            System.debug('Query : ' + query);
+           
             hccList = Database.query(query);
-            System.debug('List Size ' + hccList.size());
+            
         }
 
     else if(filterValue == Label.TPL_Records_Created_Today) {
@@ -67,7 +67,7 @@ try{
         query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \''+ caseId + '\' AND RecordTypeId = \'' 
         + recordTypeId +'\' AND Source_System_ID__c = ' + sourceSystemId +' AND CreatedDate = TODAY AND dateId__c < \''+ dateId 
         +'\' ORDER BY dateId__c DESC LIMIT '+ pageSize;
-        System.debug('Query : ' + query);
+        
         hccList = Database.query(query);
 
     }
@@ -90,10 +90,10 @@ try{
     
             query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId + '\' AND RecordTypeId = \'' 
             + recordTypeId + '\' AND dateId__c < \'' + dateId +'\' ORDER BY dateId__c DESC LIMIT ' + pageSize;
-            System.debug('Query : ' + query);
+            
             hccList = Database.query(query);
         }
-        System.debug('Start Item Number : ' + startItemNumber + ', Items to remove : ' + itemsToRemove +', Page Size : ' + pageSize +', List Size : ' + hccList.size());
+       
     }
     
     else
@@ -116,7 +116,7 @@ try{
         
             query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \''+caseId + '\' AND RecordTypeId = \''
             + recordTypeId + '\' AND Source_System_ID__c = '+ sourceSystemId +' AND dateId__c > \'' + dateId + '\' ORDER BY dateId__c ASC LIMIT '+ pageSize;
-            System.debug('Query : ' + query);
+          
             hccList = Database.query(query);
             
         }
@@ -141,7 +141,7 @@ try{
             query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId +'\' AND RecordTypeId = \'' 
             + recordTypeId +'\' AND Source_System_ID__c = ' + sourceSystemId + ' AND CreatedDate = TODAY AND dateId__c > \'' + dateId 
             +'\' ORDER BY dateId__c ASC LIMIT ' + pageSize;
-            System.debug('Query : ' + query);
+            
             hccList = Database.query(query);
     
         }
@@ -164,10 +164,10 @@ try{
         
             query = 'SELECT ' + fields + ' FROM Healthcare_Cost__c WHERE Case2__c = \'' + caseId + '\' AND RecordTypeId = \''
             + recordTypeId + '\' AND dateId__c > \'' + dateId + '\' ORDER BY dateId__c ASC LIMIT ' + pageSize;
-            System.debug('Query : ' + query);
+            
             hccList = Database.query(query);
         }
-        System.debug('Start Item Number : ' + startItemNumber + ', Items to remove : ' + itemsToRemove +', Page Size : ' + pageSize +', List Size : ' + hccList.size());
+        
     }
 
     

--- a/TPL/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/TPL/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -29,6 +29,13 @@
         <value>Id, Name, Case2__c, Case_Number__c, Cost_Include__c, Cost_Review__c, Date_of_Service__c, Location_Responded__c, Basic_Amount__c, Cost__c, Total_Cost_Override__c, Site_Code__c, Facility__c, FacilityName__c, Fixed_Wing_Helicopter__c, Source_System_ID__c</value>
     </labels>
     <labels>
+        <fullName>TPL_Ascending</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>TPL_Ascending</shortDescription>
+        <value>asc</value>
+    </labels>
+    <labels>
         <fullName>TPL_Both_Checked</fullName>
         <language>en_US</language>
         <protected>false</protected>
@@ -62,6 +69,13 @@
         <protected>false</protected>
         <shortDescription>Cost Review Checked</shortDescription>
         <value>Cost Review Checked</value>
+    </labels>
+    <labels>
+        <fullName>TPL_Descending</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>TPL_Descending</shortDescription>
+        <value>desc</value>
     </labels>
     <labels>
         <fullName>TPL_Empty_Selection</fullName>

--- a/TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
@@ -103,6 +103,7 @@ export default class AmbulanceRecordsAccount extends LightningElement {
 
     connectedCallback(){
         this.selectedFilter = 'All Records';
+        this.sortSelection = 'ASC';
         this.recordId;
         this.pageNumber = 1;
         this.pageSize = this.pageSizeOptions[0]; 
@@ -112,11 +113,13 @@ export default class AmbulanceRecordsAccount extends LightningElement {
     doSorting(event) {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
+        console.log('Sort Direction : ' + this.sortDirection);
         this.sortData(this.sortBy, this.sortDirection);
     }
 
     sortData(fieldname, direction) {
         let parseData = JSON.parse(JSON.stringify(this.recordsToDisplay));
+        
         // Return the value stored in the field
         let keyValue = (a) => {
             return a[fieldname];

--- a/TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
@@ -10,22 +10,19 @@ const COLUMNS = [
         label: 'Case Number',
         fieldName: 'Case_Number__c',
         type: 'text',
-        sortable: true,
-        editable: false,
+        editable: false
     },
     {
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:false,
-        sortable: true
+        editable:false
     },
     {
         label: 'Date of Service',
@@ -42,50 +39,43 @@ const COLUMNS = [
         label: 'Location Responded',
         fieldName: 'Location_Responded__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Facility Code',
         fieldName: 'Site_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Facility',
         fieldName:'FacilityName__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Basic Amount',
         fieldName: 'Basic_Amount__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Fixed Wing Helicopter',
         fieldName: 'Fixed_Wing_Helicopter__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 ];
 

--- a/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
@@ -163,6 +163,7 @@ export default class AmbulanceRecordsCase extends LightningElement {
     records = []; //All records available in the data table
     isFirstPage = true;
     isLastPage = false;
+    sortSelection = 'asc';
     totalRecords = 0; //Total no.of records
     totalPages; //Total no.of pages
     pageNumber = 1; //Page number
@@ -190,6 +191,7 @@ export default class AmbulanceRecordsCase extends LightningElement {
 
     connectedCallback() {
         this.selectedFilter = 'All Records';
+        this.sortSelection = 'asc';
         this.hideDeleteButton = true;
         this.pageSize = this.pageSizeOptions[0]; 
         this.pageNumber = 1;
@@ -227,10 +229,11 @@ export default class AmbulanceRecordsCase extends LightningElement {
     }
 
     onLoad(){
-        return getHealthcareCostsAmbulanceForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber})
+        return getHealthcareCostsAmbulanceForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber, sortOrder: this.sortSelection})
         .then(result=>{
             this.wiredRecords = result.hccList;
             this.recordsToDisplay = [];
+           console.log(result.hccList.length);
            console.log( this.wiredRecords);
             if(result.hccList != null && result.hccList){
                 this.records = JSON.parse(JSON.stringify(result.hccList));
@@ -377,7 +380,10 @@ export default class AmbulanceRecordsCase extends LightningElement {
     doSorting(event) {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
-        this.sortData(this.sortBy, this.sortDirection);
+        this.sortSelection = this.sortDirection;
+        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
+        this.onLoad();
+       // this.sortData(this.sortBy, this.sortDirection);
     }
 
     sortData(fieldname, direction) {

--- a/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
@@ -233,8 +233,6 @@ export default class AmbulanceRecordsCase extends LightningElement {
         .then(result=>{
             this.wiredRecords = result.hccList;
             this.recordsToDisplay = [];
-           console.log(result.hccList.length);
-           console.log( this.wiredRecords);
             if(result.hccList != null && result.hccList){
                 this.records = JSON.parse(JSON.stringify(result.hccList));
                 this.records.forEach(record =>{
@@ -292,11 +290,11 @@ export default class AmbulanceRecordsCase extends LightningElement {
     }
     changeCostReview(event){
         this.costReview = event.target.checked;
-        console.log(this.costReview);
+        
     }
     changeCostInclude(event){
         this.costInclude = event.target.checked;
-        console.log(this.costInclude);
+        
     }
     updateAll(){
         updateAll({caseId: this.recordId,costReview:this.costReview,costInclude:this.costInclude,currentRecords:this.recordsToDisplay})
@@ -381,7 +379,6 @@ export default class AmbulanceRecordsCase extends LightningElement {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
         this.sortSelection = this.sortDirection;
-        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
         this.onLoad();
        // this.sortData(this.sortBy, this.sortDirection);
     }

--- a/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
@@ -12,15 +12,13 @@ const MANUAL_COLUMNS = [
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        sortable: true,
-        editable: true
+        sortable: true
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        sortable: true,
-        editable:true
+        sortable: true
     },
     {
         label: 'Date of Service',
@@ -37,15 +35,13 @@ const MANUAL_COLUMNS = [
         label: 'Location Responded',
         fieldName: 'Location_Responded__c',
         type:'text',
-        editable: true,
-        sortable:true
+        editable: true
     },
     {
         label: 'Facility Code',
         fieldName: 'Site_Code__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Facility',
@@ -65,36 +61,32 @@ const MANUAL_COLUMNS = [
         },
         cellAttributes:{
             class: { fieldName: 'accountNameClass'}
-        },
-        sortable: true
+        }
+       
     },
     {
         label: 'Basic Amount',
         fieldName: 'Basic_Amount__c',
         type: 'currency',
-        sortable: true,
         editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        sortable: true,
         editable: true
     },
     {
         label: 'Fixed Wing/Helicopter',
         fieldName: 'Fixed_Wing_Helicopter__c',
         type: 'currency',
-        editable: true,
-        sortable: false
+        editable: true
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     }
 ];
 
@@ -103,15 +95,13 @@ const INTEGRATION_COLUMNS = [
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Date of Service',
@@ -128,50 +118,43 @@ const INTEGRATION_COLUMNS = [
         label: 'Location Responded',
         fieldName: 'Location_Responded__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Facility Code',
         fieldName: 'Site_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Facility',
         fieldName:'FacilityName__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Basic Amount',
         fieldName: 'Basic_Amount__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Fixed Wing Helicopter',
         fieldName: 'Fixed_Wing_Helicopter__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 ];
 export default class AmbulanceRecordsCase extends LightningElement {

--- a/TPL/force-app/main/default/lwc/continuingcareRecordsAccount/continuingcareRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/continuingcareRecordsAccount/continuingcareRecordsAccount.js
@@ -8,21 +8,18 @@ const COLUMNS = [
         label: 'Case',
         fieldName: 'Case_Number__c',
         type:'text',
-        sortable: true,
         editable:false
     },
     {
         label: 'Description',
         fieldName: 'Description__c',
         type:'text',
-        sortable: true,
         editable:false
     },
     {
         label: 'Cost',
         fieldName: 'Cost__c',
         type: 'currency',
-        sortable: true,
         editable: false
     }
 ];

--- a/TPL/force-app/main/default/lwc/continuingcareRecordsCase/continuingcareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/continuingcareRecordsCase/continuingcareRecordsCase.js
@@ -12,14 +12,12 @@ const COLUMNS = [
         label: 'Description',
         fieldName: 'Description__c',
         type:'text',
-        sortable: true,
         editable:true
     },
     {
         label: 'Cost',
         fieldName: 'Cost__c',
         type: 'currency',
-        sortable: true,
         editable: true
     }
 ];

--- a/TPL/force-app/main/default/lwc/continuingcareRecordsCase/continuingcareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/continuingcareRecordsCase/continuingcareRecordsCase.js
@@ -30,6 +30,7 @@ export default class ContinuingcareRecordsCase extends LightningElement {
     isFirstPage = true;
     isLastPage = false;
     hideDeleteButton = true;
+    sortSelection = 'asc'; // sort selection
     totalRecords = 0; //Total no.of records
     totalPages; //Total no.of pages
     pageNumber = 1; //Page number
@@ -49,6 +50,7 @@ export default class ContinuingcareRecordsCase extends LightningElement {
     connectedCallback(){
         this.selectedFilter= 'Manual Records';
         this.hideDeleteButton = false;
+        this. sortSelection = 'asc';
         this.pageSize = this.pageSizeOptions[0]; 
         this.pageNumber = 1;
         this.onLoad();
@@ -83,7 +85,7 @@ export default class ContinuingcareRecordsCase extends LightningElement {
     }
  
     onLoad(){
-        return getHealthcareCostsCCForCase({caseId: this.recordId, filterValue: this.selectedFilter ,pageNumber: this.pageNumber, pageSize: this.pageSize})
+        return getHealthcareCostsCCForCase({caseId: this.recordId, filterValue: this.selectedFilter ,pageNumber: this.pageNumber, pageSize: this.pageSize, sortOrder: this.sortSelection})
         .then(result =>{
             this.recordsToDisplay = [];
 

--- a/TPL/force-app/main/default/lwc/futurecareRecordsAccount/futurecareRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/futurecareRecordsAccount/futurecareRecordsAccount.js
@@ -8,21 +8,18 @@ const COLUMNS = [
         label: 'Case',
         fieldName: 'Case_Number__c',
         type:'text',
-        sortable: true,
         editable:false
     },
     {
         label: 'Description',
         fieldName: 'Description__c',
         type:'text',
-        sortable: true,
         editable:false
     },
     {
         label: 'Cost',
         fieldName: 'Cost__c',
         type: 'currency',
-        sortable: true,
         editable: false
     }
 ];

--- a/TPL/force-app/main/default/lwc/futurecareRecordsCase/futurecareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/futurecareRecordsCase/futurecareRecordsCase.js
@@ -13,14 +13,12 @@ const COLUMNS = [
         label: 'Description',
         fieldName: 'Description__c',
         type:'text',
-        sortable: true,
         editable:true
     },
     {
         label: 'Cost',
         fieldName: 'Cost__c',
         type: 'currency',
-        sortable: true,
         editable: true
     }
 ];

--- a/TPL/force-app/main/default/lwc/futurecareRecordsCase/futurecareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/futurecareRecordsCase/futurecareRecordsCase.js
@@ -36,6 +36,7 @@ export default class FuturecareRecordsCase extends LightningElement {
     pageSizeOptions = [5, 10, 25, 50, 75, 100]; //Page size options
     pageSize; //No.of records to be displayed per page
     recordsToDisplay = []; //Records to be displayed on the page
+    sortSelection = 'asc'; // sort selection
     wiredRecords;
     updateMessage='';
     draftValues = [];
@@ -51,6 +52,7 @@ export default class FuturecareRecordsCase extends LightningElement {
     connectedCallback(){
         this.selectedFilter= 'Manual Records';
         this.hideDeleteButton = false;
+        this. sortSelection = 'asc';
         this.pageSize = this.pageSizeOptions[0]; 
         this.pageNumber = 1;
         this.onLoad();
@@ -85,7 +87,7 @@ export default class FuturecareRecordsCase extends LightningElement {
     }
 
     onLoad(){
-        return getHealthcareCostsFCForCase({caseId: this.recordId, pageNumber: this.pageNumber, pageSize: this.pageSize})
+        return getHealthcareCostsFCForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageNumber: this.pageNumber, pageSize: this.pageSize, sortOrder: this.sortSelection})
         .then(result =>{
             this.recordsToDisplay = [];
 

--- a/TPL/force-app/main/default/lwc/hospitalRecordsAccount/hospitalRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsAccount/hospitalRecordsAccount.js
@@ -10,22 +10,19 @@ const COLUMNS = [
         label: 'Case Number',
         fieldName: 'Case_Number__c' ,
         type: 'text',
-        sortable: true,
         editable: false,
     },
     {
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:false,
-        sortable: true
+        editable:false
     },
     {
         label: 'Date of Service',
@@ -42,43 +39,37 @@ const COLUMNS = [
         label: 'Location of Incident',
         fieldName: 'Location_of_Incident__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Description of Incident',
         fieldName: 'Description_of_Incident__c',
         type: 'text',
-        editable: false,
-        sortable: true,
+        editable: false
     },
     {
         label: 'Intervention Code (CCI)',
         fieldName: 'Intervention_Code_CCI__c',
         type: 'text',
-        editable: false,
-        sortable: true,
+        editable: false
     },
     {
         label: 'CCI Level',
         fieldName: 'CCI_Level__c',
         type: 'text',
-        editable: false,
-        sortable: true,
+        editable: false
     },
     {
         label: 'Facility Code',
         fieldName: 'Site_Code__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Facility',
         fieldName: 'FacilityName__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Date of Admission',
@@ -88,8 +79,7 @@ const COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Date of Discharge',
@@ -99,62 +89,53 @@ const COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Number of Days',
         fieldName: 'Number_of_Days__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: ' Service Provided by Facility',
         fieldName: 'Service_Provider_Facility__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
     
         label: 'Service Type',
         fieldName: 'Service_Type2__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Standard Daily Rate',
         type: 'currency',
         fieldName: 'Standard_Daily_Rate__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Standard',
         fieldName: 'Total_Costs_Standard__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Diagnostic Treatment Service',
         fieldName : 'Diagnostic_Treatment_Service2__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Souce System ID',
         fieldName : 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 
 ];

--- a/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
@@ -13,15 +13,13 @@ const INTEGRATION_COLUMNS = [
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:true,
-        sortable: true
+        editable:true
     },
     {
         label: 'Date of Service',
@@ -38,43 +36,37 @@ const INTEGRATION_COLUMNS = [
         label: 'Location of Incident',
         fieldName: 'Location_of_Incident__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Description of Incident',
         fieldName: 'Description_of_Incident__c',
         type: 'text',
-        editable: false,
-        sortable: true,
+        editable: false
     },
     {
         label: 'Intervention Code (CCI)',
         fieldName: 'Intervention_Code_CCI__c',
         type: 'text',
-        editable: false,
-        sortable: true,
+        editable: false
     },
     {
         label: 'CCI Level',
         fieldName: 'CCI_Level__c',
         type: 'text',
-        editable: false,
-        sortable: true,
+        editable: false
     },
     {
         label: 'Facility Code',
         fieldName: 'Site_Code__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Facility',
         fieldName: 'FacilityName__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Date of Admission',
@@ -84,8 +76,7 @@ const INTEGRATION_COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Date of Discharge',
@@ -95,14 +86,12 @@ const INTEGRATION_COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Number of Days',
         fieldName: 'Number_of_Days__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: ' Service Provided by Facility',
@@ -122,50 +111,43 @@ const INTEGRATION_COLUMNS = [
         },
         cellAttributes:{
             class: { fieldName: 'accountNameClass'}
-        },
-        sortable: true
+        }
     },
     {
     
         label: 'Service Type',
         fieldName: 'Service_Type2__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Standard Daily Rate',
         type: 'currency',
         fieldName: 'Standard_Daily_Rate__c',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Standard',
         fieldName: 'Total_Costs_Standard__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Diagnostic Treatment Service',
         fieldName :'Diagnostic_Treatment_Service2__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 ];
 
@@ -874,7 +856,7 @@ export default class HospitalRecordsCase extends LightningElement {
             this.dispatchEvent(
                 new ShowToastEvent({
                     title: 'Error',
-                    message: 'Some issues occured while loading Hospital Records. Please contact Administrator',
+                    message: 'Some issues occured while loading Ambulance Records. Please contact Administrator',
                     variant: 'error'
                 })
             );    

--- a/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
@@ -524,7 +524,6 @@ export default class HospitalRecordsCase extends LightningElement {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
         this.sortSelection = this.sortDirection;
-        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
         this.onLoad();
       //  this.sortData(this.sortBy, this.sortDirection);
     }
@@ -844,11 +843,11 @@ export default class HospitalRecordsCase extends LightningElement {
     }
     changeCostReview(event){
         this.costReview = event.target.checked;
-        console.log(this.costReview);
+       
     }
     changeCostInclude(event){
         this.costInclude = event.target.checked;
-        console.log(this.costInclude);
+       
     }
     updateAll(){
         updateAll({caseId: this.recordId,costReview:this.costReview,costInclude:this.costInclude,currentRecords:this.recordsToDisplay})

--- a/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
@@ -332,6 +332,7 @@ export default class HospitalRecordsCase extends LightningElement {
     records = []; //All records available in the data table
     isFirstPage = true;
     isLastPage = false;
+    sortSelection = 'asc';
     totalRecords = 0; //Total no.of records
     totalPages; //Total no.of pages
     pageNumber = 1; //Page number
@@ -359,6 +360,7 @@ export default class HospitalRecordsCase extends LightningElement {
 
     connectedCallback() {
         this.selectedFilter = 'All Records';
+        this.sortSelection = 'asc';
         this.hideDeleteButton = true;
         this.pageSize = this.pageSizeOptions[0]; 
         this.pageNumber = 1;
@@ -399,7 +401,7 @@ export default class HospitalRecordsCase extends LightningElement {
     }
 
       onLoad(){
-        return getHealthcareCostsHospitalForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber})
+        return getHealthcareCostsHospitalForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber, sortOrder: this.sortSelection})
         .then(result=>{
             this.wiredRecords = result.hccList;
             this.recordsToDisplay = [];
@@ -521,7 +523,10 @@ export default class HospitalRecordsCase extends LightningElement {
     doSorting(event) {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
-        this.sortData(this.sortBy, this.sortDirection);
+        this.sortSelection = this.sortDirection;
+        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
+        this.onLoad();
+      //  this.sortData(this.sortBy, this.sortDirection);
     }
 
     sortData(fieldname, direction) {

--- a/TPL/force-app/main/default/lwc/mspRecordsAccount/mspRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/mspRecordsAccount/mspRecordsAccount.js
@@ -10,22 +10,19 @@ const COLUMNS = [
         label: 'Case Number',
         fieldName: 'Case_Number__c',
         type:'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:false,
-        sortable: true
+        editable:false
     },
     {
         label: 'Date of Service',
@@ -42,113 +39,97 @@ const COLUMNS = [
         label: 'Facility',
         fieldName: 'FacilityName__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Facility Type',
         fieldName: 'Facility_Type__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Descripiton of Service',
         fieldName: 'Description_of_Service2__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Fee Item Code',
         fieldName: 'Fee_Item_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Fee Item Title',
         fieldName: 'Fee_Item_Title__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Fee Item Description',
         fieldName: 'Fee_Item_Description__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Practitioner Number',
         fieldName: 'Practitioner_Number__c',
         type: 'false',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Practitioner Name',
         fieldName: 'Practitioner_Name__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Diagnostic Code',
         fieldName: 'Diagnostic_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Diagnostic Description',
         fieldName: 'Diagnostic_Description__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Amount Paid',
         fieldName: 'Amount_Paid__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Speciality Code',
         fieldName: 'Specialty_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Speciality Description',
         fieldName: 'Specialty_Description2__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Payee Number',
         fieldName: 'Payee_Number__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Payee Descripiton',
         fieldName: 'Payee_Description__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Service Start Date',
@@ -158,8 +139,7 @@ const COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Service Finish Date',
@@ -169,8 +149,7 @@ const COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Location Type Code',
@@ -183,15 +162,13 @@ const COLUMNS = [
         label: 'Location Type Description',
         fieldName: 'Location_Type_Description2__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     }
 ];
 

--- a/TPL/force-app/main/default/lwc/mspRecordsCase/mspRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/mspRecordsCase/mspRecordsCase.js
@@ -350,6 +350,7 @@ export default class AmbulanceRecordsCase extends LightningElement {
     isLastPage = false;
     totalRecords = 0; //Total no.of records
     totalPages; //Total no.of pages
+    sortSelection = 'asc'; // sort selection
     pageNumber = 1; //Page number
     pageSizeOptions = [5, 10, 25, 50, 75, 100]; //Page size options
     pageSize; //No.of records to be displayed per page
@@ -376,6 +377,7 @@ export default class AmbulanceRecordsCase extends LightningElement {
     connectedCallback() {
         this.selectedFilter = 'All Records';
         this.hideDeleteButton = true;
+        this.sortSelection = 'asc';
         this.pageSize = this.pageSizeOptions[0]; 
         this.pageNumber = 1;
         this.onLoad();
@@ -417,7 +419,7 @@ export default class AmbulanceRecordsCase extends LightningElement {
         }
      }
     onLoad(){
-        return getHealthcareCostsMSPForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber})
+        return getHealthcareCostsMSPForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber, sortOrder: this.sortSelection})
         .then(result=>{
             this.wiredRecords = result.hccList;
             this.recordsToDisplay = [];
@@ -535,7 +537,10 @@ export default class AmbulanceRecordsCase extends LightningElement {
     doSorting(event) {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
-        this.sortData(this.sortBy, this.sortDirection);
+        this.sortSelection = this.sortDirection;
+        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
+        this.onLoad();
+        //  this.sortData(this.sortBy, this.sortDirection);
     }
 
     sortData(fieldname, direction) {

--- a/TPL/force-app/main/default/lwc/mspRecordsCase/mspRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/mspRecordsCase/mspRecordsCase.js
@@ -538,7 +538,6 @@ export default class AmbulanceRecordsCase extends LightningElement {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
         this.sortSelection = this.sortDirection;
-        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
         this.onLoad();
         //  this.sortData(this.sortBy, this.sortDirection);
     }
@@ -602,11 +601,11 @@ export default class AmbulanceRecordsCase extends LightningElement {
     }
     changeCostReview(event){
         this.costReview = event.target.checked;
-        console.log(this.costReview);
+       
     }
     changeCostInclude(event){
         this.costInclude = event.target.checked;
-        console.log(this.costInclude);
+        
     }
     updateAll(){
         updateAll({caseId: this.recordId,costReview:this.costReview,costInclude:this.costInclude,currentRecords:this.recordsToDisplay})

--- a/TPL/force-app/main/default/lwc/mspRecordsCase/mspRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/mspRecordsCase/mspRecordsCase.js
@@ -13,15 +13,13 @@ const INTEGRATION_COLUMNS = [
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:true,
-        sortable: true
+        editable:true
     },
     {
         label: 'Date of Service',
@@ -38,92 +36,79 @@ const INTEGRATION_COLUMNS = [
         label: 'Facility',
         fieldName: 'FacilityName__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Facility Type',
         fieldName: 'Facility_Type__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Descripiton of Service',
         fieldName: 'Description_of_Service2__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Fee Item Code',
         fieldName: 'Fee_Item_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Fee Item Title',
         fieldName: 'Fee_Item_Title__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Fee Item Description',
         fieldName: 'Fee_Item_Description__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Practitioner Number',
         fieldName: 'Practitioner_Number__c',
         type: 'false',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Practitioner Name',
         fieldName: 'Practitioner_Name__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Diagnostic Code',
         fieldName: 'Diagnostic_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Diagnostic Description',
         fieldName: 'Diagnostic_Description__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Amount Paid',
         fieldName: 'Amount_Paid__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Speciality Code',
         fieldName: 'Specialty_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Speciality Description',
@@ -136,15 +121,13 @@ const INTEGRATION_COLUMNS = [
         label: 'Payee Number',
         fieldName: 'Payee_Number__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Payee Descripiton',
         fieldName: 'Payee_Description__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Service Start Date',
@@ -154,8 +137,7 @@ const INTEGRATION_COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Service Finish Date',
@@ -165,29 +147,25 @@ const INTEGRATION_COLUMNS = [
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Location Type Code',
         fieldName: 'Location_Type_Code__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Location Type Description',
         fieldName: 'Location_Type_Description2__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 ];
 const MANUAL_COLUMNS = 
@@ -196,15 +174,13 @@ const MANUAL_COLUMNS =
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:true,
-        sortable: true
+        editable:true
     },
     {
         label: 'Date of Service',
@@ -235,113 +211,97 @@ const MANUAL_COLUMNS =
         },
         cellAttributes:{
             class: { fieldName: 'accountNameClass'}
-        },
-        sortable: true
+        }
     },
     {
         label: 'Facility Type',
         fieldName: 'Facility_Type__c',
         type: 'text',
-        editable: false,
-        sortable: false
+        editable: false
     },
     {
         label: 'Descripiton of Service',
         fieldName: 'Description_of_Service2__c',
         type: 'text',
-        editable: true,
-        sortable: false
+        editable: true
     },
     {
         label: 'Fee Item Code',
         fieldName: 'Fee_Item_Code__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Fee Item Title',
         fieldName: 'Fee_Item_Title__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Fee Item Description',
         fieldName: 'Fee_Item_Description__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Practitioner Number',
         fieldName: 'Practitioner_Number__c',
         type: 'false',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Practitioner Name',
         fieldName: 'Practitioner_Name__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Diagnostic Code',
         fieldName: 'Diagnostic_Code__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Diagnostic Description',
         fieldName: 'Diagnostic_Description__c',
         type: 'text',
-        editable: true,
-        sortable: false
+        editable: true
     },
     {
         label: 'Amount Paid',
         fieldName: 'Amount_Paid__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Speciality Code',
         fieldName: 'Specialty_Code__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Speciality Description',
         fieldName: 'Specialty_Description2__c',
         type: 'text',
-        editable: true,
-        sortable: false
+        editable: true
     },
     {
         label: 'Payee Number',
         fieldName: 'Payee_Number__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Payee Descripiton',
         fieldName: 'Payee_Description__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Service Start Date',
@@ -351,8 +311,7 @@ const MANUAL_COLUMNS =
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Service Finish Date',
@@ -362,29 +321,25 @@ const MANUAL_COLUMNS =
             day: "2-digit",
             month: "2-digit",
             year: "numeric"},
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Location Type Code',
         fieldName: 'Location_Type_Code__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Location Type Description',
         fieldName: 'Location_Type_Description2__c',
         type: 'text',
-        editable: true,
-        sortable: false
+        editable: true
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: true,
-        sortable: true
+        editable: true
     }
 ];
 export default class AmbulanceRecordsCase extends LightningElement {

--- a/TPL/force-app/main/default/lwc/pharmacareRecordsAccount/pharmacareRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/pharmacareRecordsAccount/pharmacareRecordsAccount.js
@@ -10,22 +10,19 @@ const COLUMNS = [
         label: 'Case Number',
         fieldName: 'Case_Number__c',
         type: 'text',
-        sortable: true,
-        editable: false,
+        editable: false
     },
     {
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:false,
-        sortable: true
+        editable:false
     },
     {
         label: 'Date of Service',
@@ -42,43 +39,37 @@ const COLUMNS = [
         label: 'Practitioner Name',
         fieldName: 'Practitioner_Name__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'DIN',
         fieldName: 'DIN__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Name of Drug',
         fieldName: 'Name_of_Drug__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost of Drug',
         fieldName: 'Cost_of_Drug__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 ];
 

--- a/TPL/force-app/main/default/lwc/pharmacareRecordsCase/pharmacareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/pharmacareRecordsCase/pharmacareRecordsCase.js
@@ -12,15 +12,13 @@ const INTEGRATION_COLUMNS = [
         label: 'Cost Include',
         fieldName: 'Cost_Include__c',
         type:'boolean',
-        editable: true,
-        sortable: true
+        editable: true
     },
     {
         label: 'Cost Review',
         fieldName: 'Cost_Review__c',
         type:'boolean',
-        editable:true,
-        sortable: true
+        editable:true
     },
     {
         label: 'Date of Service',
@@ -37,43 +35,37 @@ const INTEGRATION_COLUMNS = [
         label: 'Practitioner Name',
         fieldName: 'Practitioner_Name__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'DIN',
         fieldName: 'DIN__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Name of Drug',
         fieldName: 'Name_of_Drug__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Cost of Drug',
         fieldName: 'Cost_of_Drug__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
-        sortable: true
+        editable: false
     },
     {
         label: 'Source System ID',
         fieldName: 'Source_System_ID__c',
         type: 'text',
-        editable: false,
-        sortable: true
+        editable: false
     }
 ];
 export default class PharmacareRecordsCase extends LightningElement {

--- a/TPL/force-app/main/default/lwc/pharmacareRecordsCase/pharmacareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/pharmacareRecordsCase/pharmacareRecordsCase.js
@@ -77,6 +77,7 @@ export default class PharmacareRecordsCase extends LightningElement {
     hideDeleteButton = true;
     totalRecords = 0; //Total no.of records
     totalPages; //Total no.of pages
+    sortSelection = 'asc'; // sort selection
     pageNumber = 1; //Page number
     pageSizeOptions = [5, 10, 25, 50, 75, 100]; //Page size options
     pageSize; //No.of records to be displayed per page
@@ -98,13 +99,14 @@ export default class PharmacareRecordsCase extends LightningElement {
     connectedCallback() {
         this.selectedFilter = 'All Records';
         this.hideDeleteButton = true;
+        this.sortSelection = 'asc';
         this.pageSize = this.pageSizeOptions[0]; 
         this.pageNumber = 1;
         this.onLoad();
       }
     
     onLoad(){
-        return getHealthcareCostsPharmacareForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber})
+        return getHealthcareCostsPharmacareForCase({caseId: this.recordId, filterValue: this.selectedFilter, pageSize: this.pageSize, pageNumber: this.pageNumber, sortOrder: this.sortSelection})
         .then(result=>{
             this.wiredRecords = result.hccList;
             this.recordsToDisplay = [];
@@ -204,7 +206,10 @@ export default class PharmacareRecordsCase extends LightningElement {
    doSorting(event) {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
-        this.sortData(this.sortBy, this.sortDirection);
+        this.sortSelection = this.sortDirection;
+        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
+        this.onLoad();
+        //  this.sortData(this.sortBy, this.sortDirection);
     }
 
     sortData(fieldname, direction) {

--- a/TPL/force-app/main/default/lwc/pharmacareRecordsCase/pharmacareRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/pharmacareRecordsCase/pharmacareRecordsCase.js
@@ -207,7 +207,6 @@ export default class PharmacareRecordsCase extends LightningElement {
         this.sortBy = event.detail.fieldName;
         this.sortDirection = event.detail.sortDirection;
         this.sortSelection = this.sortDirection;
-        console.log('Sort Direction : ' + this.sortSelection + ' , ' + this.sortDirection);
         this.onLoad();
         //  this.sortData(this.sortBy, this.sortDirection);
     }
@@ -342,11 +341,11 @@ export default class PharmacareRecordsCase extends LightningElement {
     }
     changeCostReview(event){
         this.costReview = event.target.checked;
-        console.log(this.costReview);
+        
     }
     changeCostInclude(event){
         this.costInclude = event.target.checked;
-        console.log(this.costInclude);
+      
     }
     updateAll(){
         updateAll({caseId: this.recordId,costReview:this.costReview,costInclude:this.costInclude,currentRecords:this.recordsToDisplay})


### PR DESCRIPTION
This PR contains the front end and back end modification of Date of Service Sorting
The date of service from Ambulance, Hospital, Pharmacare, MSP are being implemented to comply with ascending and descending sorting.
Custom label included for sort variables.
Updates functionalities in branch:
Apex Class:
HCCostCaseController
HCCostCaseDAO

LWC Components:
ambulanceRecordsCase
ambulanceRecordsAccount (removing the sort access)
hospitalRecordsCase
hospitalRecordsAccount (removing the sort access)
continuingcareCase  (removing the sort access)
continuingcareAccount  (removing the sort access)
futurecareCase  (removing the sort access)
futurecareAccount  (removing the sort access)
mspRecordsAccount  (removing the sort access)
mspRecordsCase
pharmacareRecordsAccount  (removing the sort access)
pharmacareRecordsCase

I will be raising more PR to accommodate Account level grid changes after this is merged. 

Could you please review and validate the PR @cgijeffolsen  @NataliaNikishina 
Thank You!
