### PR TITLE
Service type checks for integration record

### DIFF
--- a/TPL/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Service_Type_checks_for_Integration.validationRule-meta.xml
+++ b/TPL/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Service_Type_checks_for_Integration.validationRule-meta.xml
@@ -4,8 +4,8 @@
     <active>true</active>
     <description>This validation rule will validate</description>
     <errorConditionFormula>$Setup.Data_Migration_Check__c.Bypass_Flow_Validations__c = FALSE &amp;&amp;
-AND (
-Source_System_ID__c &lt;&gt; &quot;&quot;,        
+AND (  NOT( ISBLANK( Source_System_ID__c ) ) ,
+ NOT( ISBLANK(  Service_Provided_by_Facility__c ) ) ,        
 TEXT(Service_Provided_by_Facility__r.Service_Type__c)  &lt;&gt; Service_Type2__c )</errorConditionFormula>
     <errorMessage>Service Type does not match with selected Service Provided by Facility.</errorMessage>
 </ValidationRule>


### PR DESCRIPTION
Hello @cgijeffolsen @rahulmantriSFDC 
We have made a quick change to validation rule based on the discussion for service types checks implementation for Hospitalization Records.
This change will comply to accept the input integration records and would trigger only when the service provided by facility is being updated manually.
Tagging Rahul for merge since Natalia is away till 11.30
