### PR TITLE
Fixing Hospitalization mass update issue

### DIFF
--- a/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
@@ -881,7 +881,8 @@ export default class HospitalRecordsCase extends LightningElement {
             .then(result=>{
                 this.onLoad();
                 this.checkIfUnderUpdate();
-               
+                this.costInclude = false;
+                this.costReview = false;
             })
             .catch(error =>{
                 this.records = []


### PR DESCRIPTION
While testing in TPLQAA ,  we spot issues with Hospitalization mass update if cost include and review were false. On analysis, the caching was happening on Hospitalization. 
Updates to js file to remove that caching by defaulting the cost include and cost review to false which is expected and done for other record types
Please review @cgijeffolsen  @NataliaNikishina  @rahulmantriSFDC 

Thank You