### PR TITLE
Update to Apex classes making them security complaint

### DIFF
--- a/TPL/force-app/main/default/classes/JWTGenerateAuthTest.cls
+++ b/TPL/force-app/main/default/classes/JWTGenerateAuthTest.cls
@@ -11,7 +11,7 @@
 public class JWTGenerateAuthTest {
         public static final String CONTENT_TYPE_HEADER = 'Content-Type';
         public static final String CONTENT_TYPE_JSON = 'application/json';
-        private static final String ACCESS_TOKEN = 'gv6iCx48OaH76ufiGXBUlRTRTXxx';
+        private static final String ACCESS_TOKEN = '00000000000000';
         private static final String EXPIRES_IN = '300';
         private static final String STATE = 'mocktestState'; 
         private static final String TOKEN_TYPE = 'Bearer'; 
@@ -40,7 +40,7 @@ public class JWTGenerateAuthTest {
         '  \"token_type\" : \"Bearer\",'+
         '  \"issued_at\" : \"1521077832490\",'+
         '  \"client_id\" : \"testKey\",'+
-        '  \"access_token\" : \"gv6iCx48OaH76ufiGXBUlRTRTXxx\",'+
+        '  \"access_token\" : \"00000000000000\",'+
         '  \"application_name\" : \"47bc6c8d-34f3-4141-b9e6-f1679a8240e7\",'+
         '  \"scope\" : \"\",'+
         '  \"expires_in\" : \"3599\",'+
@@ -256,7 +256,7 @@ public class JWTGenerateAuthTest {
         System.AssertEquals('bobbywhite-eval',resp.organization_name);
         System.AssertEquals('Bearer',resp.token_type);
         System.AssertEquals('1521077832490',resp.issued_at);
-        System.AssertEquals('gv6iCx48OaH76ufiGXBUlRTRTXxx',resp.access_token);
+        System.AssertEquals('00000000000000',resp.access_token);
         System.AssertEquals('47bc6c8d-34f3-4141-b9e6-f1679a8240e7',resp.application_name);
         System.AssertEquals('',resp.scope);
         System.AssertEquals('3599',resp.expires_in);

--- a/TPL/force-app/main/default/classes/KeyCloakhubAuth.cls
+++ b/TPL/force-app/main/default/classes/KeyCloakhubAuth.cls
@@ -1,50 +1,49 @@
-/**
-  Custom Auth Provider for AIMS API Gateway
-
-  Implements the Client Credentials flow which is intended for server-to-server integrations.
-
-**/
+/*
+* Company: CGI for BC Ministry of Health
+* Date: May 30, 2023
+* Author: Crystal Zhu, Anudish Jinturkar
+* Description: Custom Auth Provider for AIMS API Gateway that implements the Client Credentials flow which is intended for server-to-server integrations.
+* History:
+*     Initial version: June 10, 2022 - CZ
+	  Revision Version : May 26, 2023 - AJ
+*/
 public class KeyCloakhubAuth extends Auth.AuthProviderPluginClass{
-
+    
     public static final String RESOURCE_CALLBACK = '/services/authcallback/';
     public static final String DEFAULT_TOKEN_TYPE = 'Bearer';
     public static final String ENCODING_XML = 'application/x-www-form-urlencoded;charset=UTF-8';
     public static final String ENCODING_JSON = 'application/json';
     public static final String DUMMY_CODE = '999';
     public static final String DOUBLEQUOTE = '"';
-
+    
     // This class is dependant on this Custom Metadata Type created to hold custom parameters
     public static final String CUSTOM_MDT_NAME = 'IDP_ClientCredentials__mdt'; 
     public static final String CMT_FIELD_CALLBACK_URL = 'Callback_URL__c';
     public static final String CMT_FIELD_PROVIDER_NAME = 'Auth_Provider_Name__c';
     public static final String CMT_FIELD_AUTHTOKEN_URL = 'Access_Token_URL__c';
-    public static final String CMT_FIELD_CLIENT_ID = 'Client_Id__c';
+    public static final String CMT_FIELD_CLIENT_ID = 'Client_ID__c';
     public static final String CMT_FIELD_CLIENT_SECRET = 'Client_Secret__c';
     public static final String CMT_FIELD_USE_JSON = 'Use_JSON_Encoding__c';
     public static final String CMT_FIELD_SCOPE = 'Scope__c';
-
+    
     public static final String GRANT_TYPE_PARAM = 'grant_type';
     public static final String CLIENT_ID_PARAM = 'client_id';
     public static final String CLIENT_SECRET_PARAM = 'client_secret';
     public static final String SCOPE_PARAM = 'scope';
     public static final String GRANT_TYPE_CLIENT_CREDS = 'client_credentials';
-
-
+    
     /**
-     Added Constructor purely for debugging purposes to have visibility as to when the class
-     is being instantiated.
+    Added Constructor purely for debugging purposes to have visibility as to when the class
+    is being instantiated.
     **/
     public KeyCloakhubAuth() {
         super();
-        System.debug('Constructor called');
     }
-    
-    
-    /**
-        Name of custom metadata type to store this auth provider configuration fields
-        This method is required by its abstract parent class.
 
-    **/
+    /**
+    Name of custom metadata type to store this auth provider configuration fields
+    This method is required by its abstract parent class.
+	**/
     public String getCustomMetadataType() {
         return CUSTOM_MDT_NAME;
     } 
@@ -53,43 +52,34 @@ public class KeyCloakhubAuth extends Auth.AuthProviderPluginClass{
     Initiate callback. No End User authorization required in this flow so skip straight to the Token request.
     The interface requires the callback url to be defined. 
     Eg: https://test.salesforce.com/services/authcallback/<authprovidername>
-    **/
+	**/
     public PageReference initiate(Map<string,string> config, String stateToPropagate) {
-        System.debug('initiate');
-
         final PageReference pageRef = new PageReference(getCallbackUrl(config)); //NOSONAR
         pageRef.getParameters().put('state',stateToPropagate);
         pageRef.getParameters().put('code',DUMMY_CODE); // Empirically found this is required, but unused
-        System.debug(pageRef.getUrl());
         return pageRef;
     } 
-
+    
     /**
-      This method composes the callback URL automatically UNLESS it has been overridden through Configuration.
-      Normally one should not override the callback URL, but it's there in case the generated URL doesn't work.
-    **/
+This method composes the callback URL automatically UNLESS it has been overridden through Configuration.
+Normally one should not override the callback URL, but it's there in case the generated URL doesn't work.
+**/
     private String getCallbackUrl(Map<string,string> config) {
         // https://{salesforce-hostname}/services/authcallback/{urlsuffix}
         final String overrideUrl = config.get(CMT_FIELD_CALLBACK_URL);
-        final String generatedUrl = URL.getSalesforceBaseUrl().toExternalForm() + RESOURCE_CALLBACK + config.get('Auth_Provider_Name__c');
-
+        final String generatedUrl = URL.getSalesforceBaseUrl().toExternalForm() + RESOURCE_CALLBACK + config.get(CMT_FIELD_PROVIDER_NAME);    
         return String.isEmpty(overrideUrl) ? generatedUrl : overrideUrl;
     }
     
     /**
     Handle callback (from initial loop back "code" step in the flow).
-    In the Client Credentials flow, this method retrieves the access token directly.
-
+    In the Client Credentials flow, this method retrieves the access token directly.    
     Required by parent class.
-
     Error handling here is a bit painful as the UI never displays the exception or error message 
-    supplied here.  The exception is thrown for Logging/Debugging purposes only. 
+    supplied here.The exception is thrown for Logging/Debugging purposes only. 
     **/
     public Auth.AuthProviderTokenResponse handleCallback(Map<string,string> config, Auth.AuthProviderCallbackState state ) {
-        System.debug('handleCallback');
         final TokenResponse response = retrieveToken(config);
-        System.debug('response.access_token:' + response.access_token);
-
         if (response.isError()) {
             throw new TokenException(response.getErrorMessage());
         }
@@ -100,28 +90,24 @@ public class KeyCloakhubAuth extends Auth.AuthProviderPluginClass{
     } 
     
     /**
-        Refresh is required by the parent class and it's used if the original Access Token has expired.
-        In the Client Credentials flow, there is no Refresh token, so its implementation is exactly the
-        same as the Initiate() step.
-    **/
+    Refresh is required by the parent class and it's used if the original Access Token has expired.
+    In the Client Credentials flow, there is no Refresh token, so its implementation is exactly the
+    same as the Initiate() step.
+	**/
     public override Auth.OAuthRefreshResult refresh(Map<String,String> config, String refreshToken) {
-        System.debug('refresh');
         final TokenResponse response = retrieveToken(config);
         return new Auth.OAuthRefreshResult(response.access_token, response.token_type);
     }
-
-       
+    
     /**
-        getUserInfo is required by the Parent class, but not fully supported by this provider.
-        Effectively the Client Credentials flow is only useful for Server-to-Server API integrations
-        and cannot be used for other contexts such as a Registration Handler for Communities.
-     **/
+    getUserInfo is required by the Parent class, but not fully supported by this provider.
+    Effectively the Client Credentials flow is only useful for Server-to-Server API integrations
+    and cannot be used for other contexts such as a Registration Handler for Communities.
+    **/
     public Auth.UserData getUserInfo(Map<string,string> config, Auth.AuthProviderTokenResponse response) {
-        System.debug('getUserInfo-was-called');
         final TokenResponse token = retrieveToken(config);
-
         final Auth.UserData userData = new Auth.UserData(
-              token.application_name // identifier
+            token.application_name // identifier
             , null // firstName
             , null // lastName
             , null // fullName
@@ -132,93 +118,51 @@ public class KeyCloakhubAuth extends Auth.AuthProviderPluginClass{
             , config.get(CMT_FIELD_PROVIDER_NAME) //provider
             , null // siteLoginUrl
             , new Map<String,String>());
-
-
         return userData;
     }
     
-    
     /**
-       Private method that gets the Auth Token using the Client Credentials Flow.
+    Private method that gets the Auth Token using the Client Credentials Flow.
     **/
-     private TokenResponse retrieveToken(Map<String,String> config) {
-         
-        System.debug('retrieveToken');
-
+    private TokenResponse retrieveToken(Map<String,String> config) {
+        // Get the Authentication Provider by Developer Name
         final Boolean useJSONEncoding = Boolean.valueOf(config.get(CMT_FIELD_USE_JSON));
-        
-        /*
-        final HttpRequest req = new HttpRequest();
-
-        final PageReference endpoint = new PageReference(config.get(CMT_FIELD_AUTHTOKEN_URL)); //NOSONAR -- Protected by RemoteSite Setting
-        if (!useJSONEncoding) { // Including the Query String breaks JSON encoded OAuth
-            endpoint.getParameters().put('grant_type',GRANT_TYPE_CLIENT_CREDS);            
-        }
-
-        // Determine whether or not to use JSON encoding
-        final String encoding = useJSONEncoding ? ENCODING_JSON : ENCODING_XML;
-        final String encodedParams = encodeParameters(config,encoding);
-
-        System.debug('Endpoint: ' + endpoint.getUrl());
-        System.debug('Content-Type:' + encoding);
-        //System.debug('Body:' + encodedParams);
-
-        req.setEndpoint(endpoint.getUrl()); 
-        req.setHeader('Content-Type',encoding); 
-        req.setMethod('POST'); 
-        req.setBody(encodedParams);
-
-        final HTTPResponse res = new Http().send(req); 
-*/
-HttpRequest req = new HttpRequest();
-req.setHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-req.setHeader('Content-Length', '0');
-req.setBody('grant_type=client_credentials&client_id=myClientId&client_secret=myClientSecret');
-req.setMethod('POST');
-req.setEndpoint('https://test-authservices.bcehs.ca/realms/BCEHS/protocol/openid-connect/token');
-String CLIENT_ID = 'MOH_TPL_Salesforce';
-String CLIENT_SECRET = 'OHTb5enndRLZwhNtQ0l3aHhU5w86d2bk';
-//request.setBody('grant_type=client_credentials&client_id=CLIENT_ID&client_secret=CLIENT_SECRET');
-
-req.setBody('grant_type=client_credentials' + '&client_id='+CLIENT_ID + '&client_secret='+CLIENT_SECRET);
-Http http = new Http();
-HTTPResponse res = http.send(req);
-        System.debug('Token Response Status: ' + res.getStatus() + ' ' + res.getStatusCode());
+        final String requestBody = GRANT_TYPE_PARAM+'='+GRANT_TYPE_CLIENT_CREDS+'&'+CLIENT_ID_PARAM+'='+config.get(CMT_FIELD_CLIENT_ID) + '&'+CLIENT_SECRET_PARAM+'='+config.get(CMT_FIELD_CLIENT_SECRET);
+        HttpRequest req = new HttpRequest();
+        req.setHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+        req.setHeader('Content-Length', '0');
+        req.setMethod('POST');
+        req.setEndpoint(config.get(CMT_FIELD_AUTHTOKEN_URL));
+        req.setBody(requestBody);
+        Http http = new Http();
+        HTTPResponse res = http.send(req);
         final Integer statusCode = res.getStatusCode();
-
         if ( statusCode == 200) {
             TokenResponse token =  deserializeToken(res.getBody());
             // Ensure values for key fields
             token.token_type = (token.token_type == null) ? DEFAULT_TOKEN_TYPE : token.token_type;
             return token;
-
         } else  {
             return deserializeToken(res.getBody());
         }
-
     }
     
     //deserialise response and return token
     @testVisible
     private TokenResponse deserializeToken(String responseBody) {
-        
-        System.debug('token response:' +responseBody);
-        
         // use default parsing for everything we can.
         TokenResponse parsedResponse = (TokenResponse) System.JSON.deserialize(responseBody, TokenResponse.class);
         // explicitly parse out the developer.email property because it's an illegal identifier
         Map<String,Object> props = (Map<String,Object>) System.JSON.deserializeUntyped(responseBody);
         parsedResponse.developer_email = (String) props.get('developer.email');
-       
         return parsedResponse;
     }
-
+    
     /**
-        Conditionally encode parameters as URL-style or JSON
+    Conditionally encode parameters as URL-style or JSON
     **/
     @testVisible
     private String encodeParameters(Map<String,String> config,String encoding) {
-
         // Pull out the subset of configured parameters that will be sent
         Map<String,String> params = new Map<String,String>();
         params.put(GRANT_TYPE_PARAM,GRANT_TYPE_CLIENT_CREDS);
@@ -228,10 +172,9 @@ HTTPResponse res = http.send(req);
         if (!String.isEmpty(scope)) {
             params.put(SCOPE_PARAM,scope);
         }
-
         return encoding == ENCODING_JSON ? encodeAsJSON(params) : encodeAsURL(params);
     }
-
+    
     private String encodeAsJSON(Map<String,String> params) {
         String output = '{';
         for (String key : params.keySet()) {
@@ -242,7 +185,7 @@ HTTPResponse res = http.send(req);
         output += '}';
         return output;
     }
-
+    
     private String encodeAsURL(Map<String,String> params) {
         String output = '';
         for (String key : params.keySet()) {
@@ -251,7 +194,7 @@ HTTPResponse res = http.send(req);
         }
         return output;
     }
-
+    
     public class TokenResponse {
         public String refresh_token_expires_in {get;set;}
         public String api_product_list {get;set;}
@@ -267,23 +210,20 @@ HTTPResponse res = http.send(req);
         public String expires_in {get;set;}
         public String refresh_count {get;set;}
         public String status {get;set;}
-
         // Apigee Edge -- hosted version uses these fields for error handling
         public String ErrorCode {get; set;}
         public String Error {get; set;}
-
         // Apigee on premise version uses this Field for error handling
         public Fault fault {get; set;}
-
+        
         public Boolean isError() {
             return Error != null || fault != null;
         }
-
+        
         public String getErrorMessage() {
             if (Error != null) {
                 return ErrorCode;
             }
-
             if (fault != null) {
                 // Substitute the error code to compose
                 return fault.faultString.replace('{0}',fault.detail.errorcode);
@@ -291,20 +231,20 @@ HTTPResponse res = http.send(req);
             return null;
         }
     }
-
+    
     public class Fault {
         public String faultstring {get;set;}
         public Detail detail {get;set;}
     }
-
+    
     public class Detail {
         public String errorcode {get;set;}
     }
-
+    
     /**
-        Custom exception type so we can wrap and rethrow
+    Custom exception type so we can wrap and rethrow
     **/
     public class TokenException extends Exception {
-
+        
     }
 }

--- a/TPL/force-app/main/default/classes/KeyCloakhubAuthTest.cls
+++ b/TPL/force-app/main/default/classes/KeyCloakhubAuthTest.cls
@@ -1,38 +1,38 @@
 /**
-  Test Class for KeyCloakhubAuth
-  
-  Custom Auth Provider 
+Test Class for KeyCloakhubAuth
 
-  Implements the Client Credentials flow which is intended for server-to-server integrations.
+Custom Auth Provider 
 
-  
+Implements the Client Credentials flow which is intended for server-to-server integrations.
+
+
 **/
 
 @IsTest(isParallel=true)
 public class KeyCloakhubAuthTest {
-        public static final String CONTENT_TYPE_HEADER = 'Content-Type';
-        public static final String CONTENT_TYPE_JSON = 'application/json';
-        private static final String ACCESS_TOKEN = 'gv6iCx48OaH76ufiGXBUlRTRTXxx';
-        private static final String EXPIRES_IN = '123';
-        private static final String STATE = 'mocktestState'; 
-        private static final String TOKEN_TYPE = 'Bearer'; 
-        
-        private static final String PROVIDER_NAME = 'UnitTestProvider'; 
-        
-        private static final String CALLBACK_URL_OVERRIDE = 
+    public static final String CONTENT_TYPE_HEADER = 'Content-Type';
+    public static final String CONTENT_TYPE_JSON = 'application/json';
+    private static final String ACCESS_TOKEN = '00000000000000';
+    private static final String EXPIRES_IN = '123';
+    private static final String STATE = 'mocktestState'; 
+    private static final String TOKEN_TYPE = 'Bearer'; 
+    
+    private static final String PROVIDER_NAME = 'UnitTestProvider'; 
+    
+    private static final String CALLBACK_URL_OVERRIDE = 
         System.URL.getSalesforceBaseUrl().getHost()+'/services/authcallback/' + PROVIDER_NAME; 
     
-        private static final String TEST_USER_EMAIL = 'developer@example.com';
-        private static final String KEY = 'testKey'; 
-        private static final String SECRET = 'testSecret'; 
-        private static final String SCOPE = 'View';
+    private static final String TEST_USER_EMAIL = 'developer@example.com';
+    private static final String KEY = 'testKey'; 
+    private static final String SECRET = 'testSecret'; 
+    private static final String SCOPE = 'View';
     
-        private static final String STATE_TO_PROPOGATE = 'testState'; 
-        private static final String ACCESS_TOKEN_URL = 
+    private static final String STATE_TO_PROPOGATE = 'testState'; 
+    private static final String ACCESS_TOKEN_URL = 
         'http://www.dummyhost.com/accessTokenUri';
-        private static final String EMPTY_VALUE = ''; 
-
-        private static final String jsonGoodToken = '{'+
+    private static final String EMPTY_VALUE = ''; 
+    
+    private static final String jsonGoodToken = '{'+
         '  \"refresh_token_expires_in\" : \"0\",'+
         '  \"api_product_list\" : \"[helloworld, HelloWorld_OAuth2-Product]\",'+
         '  \"api_product_list_json\" : [ \"helloworld\", \"HelloWorld_OAuth2-Product\" ],'+
@@ -41,18 +41,18 @@ public class KeyCloakhubAuthTest {
         '  \"token_type\" : \"Bearer\",'+
         '  \"issued_at\" : \"1521077832490\",'+
         '  \"client_id\" : \"testKey\",'+
-        '  \"access_token\" : \"gv6iCx48OaH76ufiGXBUlRTRTXxx\",'+
+        '  \"access_token\" : \"00000000000000\",'+
         '  \"application_name\" : \"47bc6c8d-34f3-4141-b9e6-f1679a8240e7\",'+
         '  \"scope\" : \"\",'+
         '  \"expires_in\" : \"3599\",'+
         '  \"refresh_count\" : \"0\",'+
         '  \"status\" : \"approved\"'+
         '}';
-        private static final String jsonError1 = '{\"fault\":{\"faultstring\":\"Invalid client identifier {0}\",\"detail\":{\"errorcode\":\"oauth.v2.InvalidClientIdentifier\"}}}';
-        private static final String jsonError2 = '{\"ErrorCode\" : \"invalid_client\", \"Error\" :\"Client credentials are invalid\"}';
-
-        private static final String jsonBadQueryParam = '{\"fault\":{\"faultstring\":\"Unresolved variable : request.header.Authorization\",\"detail\":{\"errorcode\":\"steps.basicauthentication.UnresolvedVariable\"}}}';
-
+    private static final String jsonError1 = '{\"fault\":{\"faultstring\":\"Invalid client identifier {0}\",\"detail\":{\"errorcode\":\"oauth.v2.InvalidClientIdentifier\"}}}';
+    private static final String jsonError2 = '{\"ErrorCode\" : \"invalid_client\", \"Error\" :\"Client credentials are invalid\"}';
+    
+    private static final String jsonBadQueryParam = '{\"fault\":{\"faultstring\":\"Unresolved variable : request.header.Authorization\",\"detail\":{\"errorcode\":\"steps.basicauthentication.UnresolvedVariable\"}}}';
+    
     
     private static Map<String,String> setupAuthProviderConfig () 
     { 
@@ -64,9 +64,9 @@ public class KeyCloakhubAuthTest {
         authProviderConfiguration.put(KeyCloakhubAuth.CMT_FIELD_CLIENT_SECRET,SECRET); 
         authProviderConfiguration.put(KeyCloakhubAuth.CMT_FIELD_SCOPE,SCOPE);
         authProviderConfiguration.put(KeyCloakhubAuth.CMT_FIELD_USE_JSON,'False');        
-       
+        
         return authProviderConfiguration; 
-    
+        
     } 
     
     static testMethod void testMetadataType()
@@ -85,10 +85,10 @@ public class KeyCloakhubAuthTest {
         
         final PageReference expectedUrl = new PageReference(authProviderConfiguration.get('Callback_URL__c'));
         expectedUrl.getParameters().put('state',STATE_TO_PROPOGATE);
-
+        
         final PageReference actualUrl = provider.initiate(authProviderConfiguration, STATE_TO_PROPOGATE); 
         System.assertEquals(expectedUrl.getParameters().get('state'), actualUrl.getParameters().get('state'));
-   
+        
     }
     
     static testMethod void testHandleCallback() 
@@ -97,7 +97,7 @@ public class KeyCloakhubAuthTest {
         final KeyCloakhubAuth provider = new KeyCloakhubAuth(); 
         
         Test.setMock(HttpCalloutMock.class, new ApigeeMockService(jsonGoodToken,200)); 
-    
+        
         final Map<String,String> queryParams = new Map<String,String>(); 
         queryParams.put('code','code'); 
         queryParams.put('state',STATE); 
@@ -107,24 +107,24 @@ public class KeyCloakhubAuthTest {
         final Auth.AuthProviderTokenResponse actualAuthProvResponse = provider.handleCallback(authProviderConfiguration, cbState); 
         
         final Auth.AuthProviderTokenResponse expectedAuthProvResponse = new Auth.AuthProviderTokenResponse(PROVIDER_NAME, ACCESS_TOKEN, SECRET, STATE); 
-    
+        
         System.assertEquals(expectedAuthProvResponse.provider, actualAuthProvResponse.provider); 
         System.assertEquals(expectedAuthProvResponse.oauthToken, actualAuthProvResponse.oauthToken); 
         System.assertEquals(expectedAuthProvResponse.oauthSecretOrRefreshToken, actualAuthProvResponse.oauthSecretOrRefreshToken); 
         System.assertEquals(expectedAuthProvResponse.state, actualAuthProvResponse.state); 
-
+        
     }
-
+    
     static testMethod void testHandleCallbackJson() 
     { 
         final Map<String,String> authProviderConfiguration = setupAuthProviderConfig();
         // override the USE_JSON config
         authProviderConfiguration.put(KeyCloakhubAuth.CMT_FIELD_USE_JSON,'True');
-
+        
         final KeyCloakhubAuth provider = new KeyCloakhubAuth(); 
         
         Test.setMock(HttpCalloutMock.class, new ApigeeMockService(jsonGoodToken,200)); 
-    
+        
         final Map<String,String> queryParams = new Map<String,String>(); 
         queryParams.put('code','code'); 
         queryParams.put('state',STATE); 
@@ -134,21 +134,21 @@ public class KeyCloakhubAuthTest {
         final Auth.AuthProviderTokenResponse actualAuthProvResponse = provider.handleCallback(authProviderConfiguration, cbState); 
         
         final Auth.AuthProviderTokenResponse expectedAuthProvResponse = new Auth.AuthProviderTokenResponse(PROVIDER_NAME, ACCESS_TOKEN, SECRET, STATE); 
-    
+        
         System.assertEquals(expectedAuthProvResponse.provider, actualAuthProvResponse.provider); 
         System.assertEquals(expectedAuthProvResponse.oauthToken, actualAuthProvResponse.oauthToken); 
         System.assertEquals(expectedAuthProvResponse.oauthSecretOrRefreshToken, actualAuthProvResponse.oauthSecretOrRefreshToken); 
         System.assertEquals(expectedAuthProvResponse.state, actualAuthProvResponse.state); 
-
+        
     }
-
+    
     static testMethod void testHandleCallbackError1() 
     { 
         final Map<String,String> authProviderConfiguration = setupAuthProviderConfig(); 
         final KeyCloakhubAuth provider = new KeyCloakhubAuth(); 
         
         Test.setMock(HttpCalloutMock.class, new ApigeeMockService(jsonError1,401)); 
-    
+        
         final Map<String,String> queryParams = new Map<String,String>(); 
         queryParams.put('code','code'); 
         queryParams.put('state',STATE); 
@@ -162,14 +162,14 @@ public class KeyCloakhubAuthTest {
             System.AssertEquals('Invalid client identifier oauth.v2.InvalidClientIdentifier',ex.getMessage());
         }
     }
-
+    
     static testMethod void testHandleCallbackError2() 
     { 
         final Map<String,String> authProviderConfiguration = setupAuthProviderConfig(); 
         final KeyCloakhubAuth provider = new KeyCloakhubAuth(); 
         
         Test.setMock(HttpCalloutMock.class, new ApigeeMockService(jsonError2,401)); 
-    
+        
         final Map<String,String> queryParams = new Map<String,String>(); 
         queryParams.put('code','code'); 
         queryParams.put('state',STATE); 
@@ -183,41 +183,41 @@ public class KeyCloakhubAuthTest {
             System.AssertEquals('invalid_client',ex.getMessage());
         }
     } 
-
+    
     static testMethod void testRefresh() {
-
+        
         final Map<String,String> config = setupAuthProviderConfig(); 
         final KeyCloakhubAuth provider = new KeyCloakhubAuth(); 
         
         Test.setMock(HttpCalloutMock.class, new ApigeeMockService(jsonGoodToken,200)); 
-
+        
         final Auth.OAuthRefreshResult actual = provider.refresh(config,'myUnusedRefreshToken');        
-    
+        
         final Auth.OAuthRefreshResult expected = new Auth.OAuthRefreshResult(ACCESS_TOKEN, TOKEN_TYPE); 
-    
+        
         System.assertEquals(expected.accessToken, actual.accessToken); 
         System.assertEquals(expected.refreshToken, actual.refreshToken); 
         System.assertEquals(expected.error,actual.error);
-
-
+        
+        
     } 
     
     static testMethod void testGetUserInfo() 
     { 
         Map<String,String> authProviderConfiguration = setupAuthProviderConfig(); 
         KeyCloakhubAuth provider = new KeyCloakhubAuth(); 
-    
+        
         Test.setMock(HttpCalloutMock.class, new ApigeeMockService(jsonGoodToken,200)); 
-    
+        
         Auth.AuthProviderTokenResponse response = new Auth.AuthProviderTokenResponse(PROVIDER_NAME, ACCESS_TOKEN ,'sampleOauthSecret', STATE); 
         Auth.UserData actualUserData = provider.getUserInfo(authProviderConfiguration, response) ; 
-    
+        
         Map<String,String> provMap = new Map<String,String>(); 
         provMap.put('key1', 'value1'); 
         provMap.put('key2', 'value2'); 
-    
+        
         final Auth.UserData expectedUserData = new Auth.UserData(
-              null // identifier
+            null // identifier
             , null // firstName
             , null // lastName
             , null  // fullName
@@ -228,7 +228,7 @@ public class KeyCloakhubAuthTest {
             , PROVIDER_NAME  // provider
             , null // siteLoginUrl
             , new Map<String,String>()); 
-    
+        
         System.assertNotEquals(actualUserData,null); 
         System.assertEquals(expectedUserData.firstName, actualUserData.firstName); 
         System.assertEquals(expectedUserData.lastName, actualUserData.lastName); 
@@ -239,58 +239,57 @@ public class KeyCloakhubAuthTest {
         System.assertEquals(expectedUserData.provider, actualUserData.provider); 
         System.assertEquals(expectedUserData.siteLoginUrl, actualUserData.siteLoginUrl); 
     } 
-
+    
     static testmethod void testEncodingAsJSON() {
         final Map<String,String> config = setupAuthProviderConfig();
-
+        
         final String output = new KeyCloakhubAuth().encodeParameters(config,KeyCloakhubAuth.ENCODING_JSON);
         System.debug('encoded jSON: ' + output);
-
+        
         // Assert that we deserialize parse the output as JSON
         Map<String,Object> result = (Map<String,Object>)JSON.deserializeUntyped(output);
- 
+        
         System.AssertEquals('client_credentials',(String)result.get(KeyCloakhubAuth.GRANT_TYPE_PARAM),'Grant type did not match');
         System.AssertEquals(KEY,(String)result.get(KeyCloakhubAuth.CLIENT_ID_PARAM),'Client key did not match');
         System.AssertEquals(SECRET,(String)result.get(KeyCloakhubAuth.CLIENT_SECRET_PARAM),'Client secret did not match');
         System.AssertEquals(SCOPE,(String)result.get(KeyCloakhubAuth.SCOPE_PARAM),'Scope did not match');
     }
-
+    
     static testmethod void testTokenMembers() {
         KeyCloakhubAuth.TokenResponse resp = (KeyCloakhubAuth.TokenResponse) JSON.deserialize(jsonGoodToken, KeyCloakhubAuth.TokenResponse.class);
-
+        
         System.AssertEquals('testKey',resp.client_id);
         System.AssertEquals('0',resp.refresh_token_expires_in);
         System.AssertEquals('[helloworld, HelloWorld_OAuth2-Product]',resp.api_product_list);
         System.AssertEquals(2,resp.api_product_list_json.size());
         System.AssertEquals('bobbywhite-eval',resp.organization_name);
-        //System.AssertEquals('developer@example.com',resp.developer_email);
         System.AssertEquals('Bearer',resp.token_type);
         System.AssertEquals('1521077832490',resp.issued_at);
-        System.AssertEquals('gv6iCx48OaH76ufiGXBUlRTRTXxx',resp.access_token);
+        System.AssertEquals('00000000000000',resp.access_token);
         System.AssertEquals('47bc6c8d-34f3-4141-b9e6-f1679a8240e7',resp.application_name);
         System.AssertEquals('',resp.scope);
         System.AssertEquals('3599',resp.expires_in);
         System.AssertEquals('0',resp.refresh_count);
         System.AssertEquals('approved',resp.status); 
     }
-
+    
     static testmethod void testErrorBad() {
         KeyCloakhubAuth.TokenResponse resp = (KeyCloakhubAuth.TokenResponse) JSON.deserialize(jsonGoodToken, KeyCloakhubAuth.TokenResponse.class);
         System.AssertEquals(null,resp.getErrorMessage());
     }
     
-     
+    
     // Implement a mock http response generator for Apigee. 
     public class ApigeeMockService implements HttpCalloutMock 
     {
         String jsonResponse;
         Integer httpCode;
-
+        
         public ApigeeMockService(String json, Integer code) {
             this.jsonResponse=json;
             this.httpCode=code;
         }
-
+        
         public HTTPResponse respond(HTTPRequest req) 
         { 
             if (req.getHeader(CONTENT_TYPE_HEADER)==CONTENT_TYPE_JSON) {


### PR DESCRIPTION
Updated the apex classes KeyCloakAuthHub , KeyCloakAuthHubTest, and JWTGenerateAuthTest. Removed hard-coding references and made them secuirty compliant. The Client ID and Client Secrets are now getting called dynamically in HeyCLoakAuthHub and respective test class updates have been made. Changes are done in TPLDev0 org and performed test on BCEHS integration which resulted in success. Also performed test classes run and ensured all the test classes are passing.
Could you please review the changes @cgijeffolsen  @RanadheerRG @NataliaNikishina 
Thank You!
