### PR TITLE
BCMOHAD-23522 || Fixed Unassign All button

### DIFF
--- a/TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
@@ -282,6 +282,7 @@ export default class AmbulanceRecordsAccount extends LightningElement {
 
     }
     handleUnassign(){
+        this.selectedCase = '';
         this.checkIfUnderUpdate();
         if(!this.updateHappening){
             this.updateTriggered = true;

--- a/TPL/force-app/main/default/lwc/hospitalRecordsAccount/hospitalRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsAccount/hospitalRecordsAccount.js
@@ -250,6 +250,7 @@ export default class HospitalRecordsAccount extends LightningElement {
         this.selectedCase = event.target.value;  
     }
     handleUnassign(){
+        this.selectedCase = '';
         this.checkIfUnderUpdate();
             if(!this.updateHappening){
                 this.updateTriggered = true;

--- a/TPL/force-app/main/default/lwc/mspRecordsAccount/mspRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/mspRecordsAccount/mspRecordsAccount.js
@@ -411,6 +411,7 @@ export default class MspRecordsAccount extends LightningElement {
     }
 
    handleUnassign(){
+        this.selectedCase = '';
         this.checkIfUnderUpdate();
             if(!this.updateHappening){
                 this.updateTriggered = true;

--- a/TPL/force-app/main/default/lwc/pharmacareRecordsAccount/pharmacareRecordsAccount.js
+++ b/TPL/force-app/main/default/lwc/pharmacareRecordsAccount/pharmacareRecordsAccount.js
@@ -298,6 +298,7 @@ export default class PharmacareRecordsAccount extends LightningElement {
     }
 
     handleUnassign(){
+        this.selectedCase = '';
         this.checkIfUnderUpdate();
             if(!this.updateHappening){
                 this.updateTriggered = true;


### PR DESCRIPTION
# Description

While we are Clicking the Unassign All button we are not making the case Id blank and reusing the assign logic. So, it is assigning the case Id when we click on Unassign All button.
As a fix making the case Id to blank and then calling the assign logic to it. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Deployment Tracker

TPL/force-app/main/default/lwc/ambulanceRecordsAccount/ambulanceRecordsAccount.js
TPL/force-app/main/default/lwc/hospitalRecordsAccount/hospitalRecordsAccount.js
TPL/force-app/main/default/lwc/mspRecordsAccount/mspRecordsAccount.js
TPL/force-app/main/default/lwc/pharmacareRecordsAccount/pharmacareRecordsAccount.js
