### PR TITLE
OmniESignatureTemplate Salesforce Version update changes

### DIFF
--- a/TPL/force-app/main/default/objects/OmniESignatureTemplate/OmniESignatureTemplate.object-meta.xml
+++ b/TPL/force-app/main/default/objects/OmniESignatureTemplate/OmniESignatureTemplate.object-meta.xml
@@ -71,20 +71,6 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
-        <actionName>New</actionName>
-        <type>Default</type>
-    </actionOverrides>
-    <actionOverrides>
-        <actionName>New</actionName>
-        <formFactor>Large</formFactor>
-        <type>Default</type>
-    </actionOverrides>
-    <actionOverrides>
-        <actionName>New</actionName>
-        <formFactor>Small</formFactor>
-        <type>Default</type>
-    </actionOverrides>
-    <actionOverrides>
         <actionName>SaveEdit</actionName>
         <type>Default</type>
     </actionOverrides>


### PR DESCRIPTION
Removed the New ActionOverride as part of workaround since the error occurred due to SF post upgrade change. 
The approved workaround was to remove sections from metadata in order to have a successful branch validation.
CC: @cgijeffolsen @mhussaincgi 