### PR TITLE
BCMOHAD-26496 : Fix to error message display on Ambulance and Hospital Refresh

### DIFF
--- a/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/ambulanceRecordsCase/ambulanceRecordsCase.js
@@ -711,15 +711,38 @@ export default class AmbulanceRecordsCase extends LightningElement {
                 this.showSection = false;
                 this.draftValues = [];
                 this.recordsToDisplay = data.updatedRecords;
-    
+                
+                if(this.updateMessage){
+                    this.updateMessage = this.updateMessage.replace(/\r\n/g, "<br />");
+                    this.showErrorMessage = true;
+                }
                 if (data.passedResult === 'Passed') {
-                    this.dispatchEvent(new ShowToastEvent({
+                        this.dispatchEvent(new ShowToastEvent({
                         title: 'Success',
                         message: 'HealthCare Cost Ambulance record(s) updated successfully',
                         variant: 'success'
                     }));
-                } else {
-                    this.dispatchEvent(new ShowToastEvent({
+                } 
+                else if(data.passedResult == 'Failed' || data.passedResult == null){
+                        this.dispatchEvent(
+                        new ShowToastEvent({
+                            title: 'Error',
+                            message: 'Please review the error message shown below and try again!',
+                            variant: 'error'
+                        })
+                    );   
+                }
+                else if(data.passedResult == 'Partial Success'){
+                        this.dispatchEvent(
+                        new ShowToastEvent({
+                            title: 'Warning',
+                            message: 'Few Healthcare Cost record(s) updated successfully. Errors on remaining shown below!',
+                            variant: 'Warning'
+                        })
+                    );
+                }
+                else {
+                        this.dispatchEvent(new ShowToastEvent({
                         title: 'Error',
                         message: 'Please review the error message shown below and try again!',
                         variant: 'error'

--- a/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
@@ -868,17 +868,47 @@ export default class HospitalRecordsCase extends LightningElement {
         saveDraftValues({ data: finalDrafts, recordDisplay: this.recordsToDisplay, recordType: 'Hospitalization' })
             .then(data => {
                 this.updateMessage = data.actionMessage;
+                this.recordsToDisplay = data.updatedRecords;
                 this.showSection = false;
                 this.draftValues = [];
-                this.recordsToDisplay = data.updatedRecords;
-    
-                if (data.passedResult === 'Passed') {
-                    this.dispatchEvent(new ShowToastEvent({
-                        title: 'Success',
-                        message: 'HealthCare Cost Hospitalization record(s) updated successfully',
-                        variant: 'success'
-                    }));
-                } else {
+                          
+                if(this.updateMessage){
+                    this.updateMessage = this.updateMessage.replace(/\r\n/g, "<br />");
+                    this.showErrorMessage = true;
+                }
+
+                if(data.passedResult == 'Passed'){
+              
+                    this.dispatchEvent(
+                        new ShowToastEvent({
+                            title: 'Success',
+                            message: 'HealthCare Cost Hospitalization record(s) updated successfully',
+                            variant: 'success'
+                        })
+                    );    
+                                 
+                }
+                else if(data.passedResult == 'Failed' || data.passedResult == null){
+                    
+                    this.dispatchEvent(
+                        new ShowToastEvent({
+                            title: 'Error',
+                            message: 'Please review the error message shown below and try again!',
+                            variant: 'error'
+                        })
+                    );   
+                } 
+                else if(data.passedResult == 'Partial Success'){
+                
+                    this.dispatchEvent(
+                        new ShowToastEvent({
+                            title: 'Warning',
+                            message: 'Few Healthcare Cost record(s) updated successfully. Errors on remaining shown below!',
+                            variant: 'Warning'
+                        })
+                    );
+                }   
+                 else {
                     this.dispatchEvent(new ShowToastEvent({
                         title: 'Error',
                         message: 'Please review the error message shown below and try again!',


### PR DESCRIPTION
BCMOHAD-26496 : Fix to error message display on Ambulance and Hospital Refresh
Refreshed issue is fixed and passed testing. We double checked on appropriate error message evaluation and display when the grid based operations are being performed.
![image](https://github.com/user-attachments/assets/0b25c518-8a24-4e12-88b9-43e9ae73b663)

