### PR TITLE
BCMOHAD-28089 - Total Cost Override made ediatable on Case Layout Hospital Grid

### DIFF
--- a/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
+++ b/TPL/force-app/main/default/lwc/hospitalRecordsCase/hospitalRecordsCase.js
@@ -137,7 +137,7 @@ const INTEGRATION_COLUMNS = [
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false
+        editable: true
     },
     {
         label: 'Diagnostic Treatment Service',
@@ -310,7 +310,7 @@ const MANUAL_COLUMNS = [
         label: 'Total Cost Override',
         fieldName: 'Total_Cost_Override__c',
         type: 'currency',
-        editable: false,
+        editable: true,
         sortable: true
     },
     {


### PR DESCRIPTION
BCMOHAD-28089 - Total Cost Override made editable on Hospital Grid Case Layout for both Manual as well as Integration records.
![image](https://github.com/user-attachments/assets/93d3934d-0229-43a6-8603-7ef0c481d417)
