### PR TITLE
BCMOHAD-30896 || Updated the DateID formula for Hospitalization

### DIFF
--- a/TPL/force-app/main/default/flows/Update_Healthcare_Cost_Fields.flow-meta.xml
+++ b/TPL/force-app/main/default/flows/Update_Healthcare_Cost_Fields.flow-meta.xml
@@ -138,17 +138,17 @@ DateId</description>
             </value>
         </assignmentItems>
         <assignmentItems>
-            <assignToReference>currentRecord.DateId__c</assignToReference>
-            <operator>Assign</operator>
-            <value>
-                <elementReference>dateidformula</elementReference>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
             <assignToReference>currentRecord.Date_of_Service__c</assignToReference>
             <operator>Assign</operator>
             <value>
                 <elementReference>$Record.Date_of_Admission__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>currentRecord.DateId__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>DateIdValueforHospitalizationformula</elementReference>
             </value>
         </assignmentItems>
         <connector>
@@ -762,7 +762,8 @@ Blank	        Blank
             <label>Facility will populate Code</label>
         </rules>
     </decisions>
-    <description>This flow performs the following actions:
+    <description>Updated the DateIdFormula for Hospitalization:
+This flow performs the following actions:
 
 1- Populates &apos;Total Cost Override&apos;, PHN, and DateID for MSP, Ambulance, Pharmacare, Continuing Care, Future Care, and Hospitalization records.
 2- Populates Facility Name from Facility Code for Ambulance and Hospitalization records.
@@ -779,6 +780,19 @@ Blank	        Blank
         <name>dateidformula</name>
         <dataType>String</dataType>
         <expression>SUBSTITUTE(if(Text({!$Record.Date_of_Service__c})==null,&apos;00000000&apos;,TEXT({!$Record.Date_of_Service__c})), &apos;_&apos;, &apos;&apos; ) &amp; &apos;&apos; &amp; {!$Record.Id}</expression>
+    </formulas>
+    <formulas>
+        <name>DateIdValueforHospitalizationformula</name>
+        <dataType>String</dataType>
+        <expression>SUBSTITUTE(
+  IF(
+    ISBLANK(TEXT({!currentRecord.Date_of_Service__c})),
+    &apos;00000000&apos;,
+    TEXT({!currentRecord.Date_of_Service__c})
+  ),
+  &apos;_&apos;,
+  &apos;&apos;
+) &amp; {!$Record.Id}</expression>
     </formulas>
     <formulas>
         <name>HospitalizationTotalCostOverride</name>


### PR DESCRIPTION
Updated the position of the DateId validation and the DateId formula for Hospitalization

**Post Deployment steps:** 
Run this query in the developer console or in work bench:
SELECT Id, Date_of_Service__c, DateId__c
FROM Healthcare_Cost__c
WHERE DateId__c LIKE '%0000000%'
AND Date_of_Service__c != null
AND RecordType.DeveloperName = 'HOSPITALIZATION'

**If you receive any response to the above query then use this code to execute in the Anonymous Window:
If not we don't need this step.**

Integer recordSize = 200;
Integer maxToProcessThisRun = 2000;
Integer processed = 0;

while (processed < maxToProcessThisRun) {
    List<Healthcare_Cost__c> scope = [
        SELECT Id, Date_of_Service__c, DateId__c FROM Healthcare_Cost__c
WHERE DateId__c LIKE '%0000000%' AND Date_of_Service__c != null
AND RecordType.DeveloperName = 'HOSPITALIZATION'
        LIMIT :recordSize ];
    if (scope.isEmpty()) break;

    for (Healthcare_Cost__c hc : scope) {
    }
    update scope;
    processed += scope.size();
    System.debug('Processed so far: ' + processed);
}
System.debug('Done. Total processed this run: ' + processed);
