### PR TITLE
BCMOHAD-31641

### DIFF
--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_AcuteProduct_Facility_Mismatch.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_AcuteProduct_Facility_Mismatch.validationRule-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Restrict_AcuteProduct_Facility_Mismatch</fullName>
+    <active>true</active>
+    <description>this validation rule is used to restrict the acute products to its related facility</description>
+    <errorConditionFormula>AND(
+    RecordType.Name = &apos;Hospitalization&apos;,
+    CONTAINS(Service_Type2__c , &quot;Acute&quot;),
+    Site_Code__c &lt;&gt; &quot;&quot;,
+    !ISBLANK(Service_Provided_by_Facility__c),
+    LEFT(Service_Provided_by_Facility__r.Name, LEN(Site_Code__c)) &lt;&gt; Site_Code__c
+    )</errorConditionFormula>
+    <errorMessage>The product must match the facility for Acute healthcare costs.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_Hosp_ProductYear_Mismatch.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_Hosp_ProductYear_Mismatch.validationRule-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Restrict_Hosp_ProductYear_Mismatch</fullName>
+    <active>true</active>
+    <description>This validation rule is used to restrict hospitalization cost products to the matching product year.</description>
+    <errorConditionFormula>AND(
+    RecordType.Name = &apos;Hospitalization&apos;,
+    !ISBLANK(Service_Provided_by_Facility__c),
+    !ISBLANK(Date_of_Admission__c),
+    OR(
+      AND(
+        MONTH(Date_of_Admission__c) &lt; 4 ,
+        !CONTAINS(Service_Provided_by_Facility__r.Name, TEXT(YEAR(Date_of_Admission__c)))
+      ),
+      AND(
+        MONTH(Date_of_Admission__c) &gt; 3 ,
+        !CONTAINS(Service_Provided_by_Facility__r.Name, TEXT(YEAR(Date_of_Admission__c) + 1))
+      ) 
+    )
+)</errorConditionFormula>
+    <errorMessage>The product must match product year for hospitalization costs.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
New validations added on the HCC Hospitalization records:

Restrict adding a Hospitalization Acute product when the selected facility does not match the site code from the Service Type field.
Restrict adding a Hospitalization product when the selected facility does not match the expected year based on the Date of Admission.