### PR TITLE
Release/0.6.6

### DIFF
--- a/force-app/main/default/classes/HCCCostControllerTest.cls
+++ b/force-app/main/default/classes/HCCCostControllerTest.cls
@@ -595,6 +595,6 @@ public class HCCCostControllerTest {
         else{
             System.assertEquals(accountCaseUpdateWrapper1.passMessage, accountCaseUpdateWrapper2.passMessage);
         }
-        
+         
     }    
 }

--- a/force-app/main/default/classes/HCCostCaseControllerTest.cls
+++ b/force-app/main/default/classes/HCCostCaseControllerTest.cls
@@ -20,7 +20,7 @@
 *     Initial version: March 30, 2023 - AJ
 *     Updates to codebase: May 10, 2023 - AJ
 *     Updates to codebase: July 4, 2023 - AJ
-*	  Updates to codebase: Nov 5, 2025 - RRG 
+*	  Updates to codebase: Nov 5, 2025 - RRG
 */
 @isTest
 public with sharing class HCCostCaseControllerTest {

--- a/force-app/main/default/classes/HCCostCaseControllerTest.cls
+++ b/force-app/main/default/classes/HCCostCaseControllerTest.cls
@@ -20,7 +20,7 @@
 *     Initial version: March 30, 2023 - AJ
 *     Updates to codebase: May 10, 2023 - AJ
 *     Updates to codebase: July 4, 2023 - AJ
-*	  Updates to codebase: Nov 5, 2025 - RRG
+*	  Updates to codebase: Nov 5, 2025 - RRG 
 */
 @isTest
 public with sharing class HCCostCaseControllerTest {

--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_AcuteProduct_Facility_Mismatch.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_AcuteProduct_Facility_Mismatch.validationRule-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Restrict_AcuteProduct_Facility_Mismatch</fullName>
+    <active>true</active>
+    <description>this validation rule is used to restrict the acute products to its related facility</description>
+    <errorConditionFormula>AND(
+    RecordType.Name = &apos;Hospitalization&apos;,
+    CONTAINS(Service_Type2__c , &quot;Acute&quot;),
+    Site_Code__c &lt;&gt; &quot;&quot;,
+    !ISBLANK(Service_Provided_by_Facility__c),
+    LEFT(Service_Provided_by_Facility__r.Name, LEN(Site_Code__c)) &lt;&gt; Site_Code__c
+    )</errorConditionFormula>
+    <errorMessage>The product must match the facility for Acute healthcare costs.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_AcuteProduct_Facility_Mismatch.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_AcuteProduct_Facility_Mismatch.validationRule-meta.xml
@@ -4,6 +4,7 @@
     <active>true</active>
     <description>this validation rule is used to restrict the acute products to its related facility</description>
     <errorConditionFormula>AND(
+    $Setup.Data_Migration_Check__c.Bypass_Flow_Validations__c = FALSE,
     RecordType.Name = &apos;Hospitalization&apos;,
     CONTAINS(Service_Type2__c , &quot;Acute&quot;),
     Site_Code__c &lt;&gt; &quot;&quot;,

--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_Hosp_ProductYear_Mismatch.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_Hosp_ProductYear_Mismatch.validationRule-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Restrict_Hosp_ProductYear_Mismatch</fullName>
+    <active>true</active>
+    <description>This validation rule is used to restrict hospitalization cost products to the matching product year.</description>
+    <errorConditionFormula>AND(
+    RecordType.Name = &apos;Hospitalization&apos;,
+    !ISBLANK(Service_Provided_by_Facility__c),
+    !ISBLANK(Date_of_Admission__c),
+    OR(
+      AND(
+        MONTH(Date_of_Admission__c) &lt; 4 ,
+        !CONTAINS(Service_Provided_by_Facility__r.Name, TEXT(YEAR(Date_of_Admission__c)))
+      ),
+      AND(
+        MONTH(Date_of_Admission__c) &gt; 3 ,
+        !CONTAINS(Service_Provided_by_Facility__r.Name, TEXT(YEAR(Date_of_Admission__c) + 1))
+      ) 
+    )
+)</errorConditionFormula>
+    <errorMessage>The product must match product year for hospitalization costs.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_Hosp_ProductYear_Mismatch.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_Hosp_ProductYear_Mismatch.validationRule-meta.xml
@@ -4,6 +4,7 @@
     <active>true</active>
     <description>This validation rule is used to restrict hospitalization cost products to the matching product year.</description>
     <errorConditionFormula>AND(
+    $Setup.Data_Migration_Check__c.Bypass_Flow_Validations__c = FALSE,
     RecordType.Name = &apos;Hospitalization&apos;,
     !ISBLANK(Service_Provided_by_Facility__c),
     !ISBLANK(Date_of_Admission__c),

--- a/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_ManHospHC_WithProductNoFacility.validationRule-meta.xml
+++ b/force-app/main/default/objects/Healthcare_Cost__c/validationRules/Restrict_ManHospHC_WithProductNoFacility.validationRule-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Restrict_ManHospHC_WithProductNoFacility</fullName>
+    <active>true</active>
+    <description>this validation rule is used to restrict manual HCC Hospitalization records from being created without a facility.</description>
+    <errorConditionFormula>$Setup.Data_Migration_Check__c.Bypass_Flow_Validations__c = FALSE &amp;&amp;
+AND(
+ISBLANK(Source_System_ID__c),
+NOT(ISBLANK(Service_Provided_by_Facility__c)),
+ISBLANK(Facility__c),
+RecordType.Name = &apos;Hospitalization&apos;
+)</errorConditionFormula>
+    <errorMessage>Product cannot be selected without a facility on hospitalization record.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
BCMOHAD-31641 Add validation rules to restrict mismatched AcuteProduct facility and hospitalization year products

BCMOHAD-31799 Added validation to restrict manual HCC hospitalization record creation when a product is selected without selecting a facility.

HCCCostControllerTest.cls is falling in production. It was already fixed in the lower environments.