### PR TITLE
BCMOHAM-33142 Updated facility code validation to support 5-digit fac…

### DIFF
--- a/force-app/main/default/objects/Account/validationRules/TPL_Site_Code_Numeric_only.validationRule-meta.xml
+++ b/force-app/main/default/objects/Account/validationRules/TPL_Site_Code_Numeric_only.validationRule-meta.xml
@@ -4,6 +4,6 @@
     <active>true</active>
     <description>Site Code must be numeric only</description>
     <errorConditionFormula>$Setup.Data_Migration_Check__c.Bypass_Flow_Validations__c = FALSE &amp;&amp;
-NOT(REGEX(  Site_Code__c  ,&quot;[0-9]{0,3}&quot;))</errorConditionFormula>
+NOT(REGEX(  Site_Code__c  ,&quot;[0-9]{0,5}&quot;))</errorConditionFormula>
     <errorMessage>Site Code must be 3 Digit Numeric value.</errorMessage>
 </ValidationRule>


### PR DESCRIPTION
@cgijeffolsen  Updated facility code validation to support up to 5-digit facility codes.

Validated that 5-digit Facilities can be created successfully.

Validated that a 5-digit Facility can be selected and used on a Manual Hospital record.

Validated that 5-digit Facility Products can be created successfully.

Validated the hidden Product Control fields:

Service Type
Service Type 2

Validated that a 5-digit Facility can be successfully bound/associated with a 5-digit Facility Product.