### PR TITLE
BCMOHAM-31957 || Updated Surgical Day Product Name Formula

### DIFF
--- a/force-app/main/default/flows/Product_Name_Creation_and_Update.flow-meta.xml
+++ b/force-app/main/default/flows/Product_Name_Creation_and_Update.flow-meta.xml
@@ -269,7 +269,7 @@
     <formulas>
         <name>SurgicalDay_Product_Name</name>
         <dataType>String</dataType>
-        <expression>{!$Record.Intervention_Code_CCI__c}+&apos;-&apos;+ {!ServiceTypeRecord} + &apos;-&apos;+ {!EffectiveYear}</expression>
+        <expression>{!$Record.Intervention_Code_CCI__c}+&apos;-&apos;+ {!ServiceTypeRecord} + &apos;-&apos;+CASE(TEXT({!$Record.CCI_Level__c}),&apos;Tier 1&apos;, &apos;Low&apos;,&apos;Tier 2&apos;, &apos;Med&apos;,&apos;Tier 3&apos;, &apos;High&apos;,&apos;&apos;)+ &apos;-&apos;+ {!EffectiveYear}</expression>
     </formulas>
     <interviewLabel>Product Name Creation and Update {!$Flow.CurrentDateTime}</interviewLabel>
     <label>TPL_Product Name Creation and Update</label>

--- a/force-app/main/default/flows/Product_Name_Creation_and_Update.flow-meta.xml
+++ b/force-app/main/default/flows/Product_Name_Creation_and_Update.flow-meta.xml
@@ -269,7 +269,9 @@
     <formulas>
         <name>SurgicalDay_Product_Name</name>
         <dataType>String</dataType>
-        <expression>{!$Record.Intervention_Code_CCI__c}+&apos;-&apos;+ {!ServiceTypeRecord} + &apos;-&apos;+CASE(TEXT({!$Record.CCI_Level__c}),&apos;Tier 1&apos;, &apos;Low&apos;,&apos;Tier 2&apos;, &apos;Med&apos;,&apos;Tier 3&apos;, &apos;High&apos;,&apos;&apos;)+ &apos;-&apos;+ {!EffectiveYear}</expression>
+        <expression>IF(  VALUE({!EffectiveYear}) &gt;= 2027,  {!$Record.Intervention_Code_CCI__c} + &apos;-&apos; +  {!ServiceTypeRecord} + &apos;-&apos; +
+    CASE( TEXT({!$Record.CCI_Level__c}), &apos;Tier 1&apos;, &apos;Low&apos;, &apos;Tier 2&apos;, &apos;Med&apos;, &apos;Tier 3&apos;, &apos;High&apos;, &apos;&apos; ) + &apos;-&apos; + {!EffectiveYear},
+    {!$Record.Intervention_Code_CCI__c} + &apos;-&apos; + {!ServiceTypeRecord} + &apos;-&apos; +{!EffectiveYear})</expression>
     </formulas>
     <interviewLabel>Product Name Creation and Update {!$Flow.CurrentDateTime}</interviewLabel>
     <label>TPL_Product Name Creation and Update</label>


### PR DESCRIPTION
Updated the Product Naming Flow to support the revised Surgical Day Care naming convention for products starting in 2027. The flow now converts Tier Level 1, 2, and 3 to Low, Med, and High respectively when generating the product name (e.g., Surgical Day Care-Low-2027). Products with an Effective Year of 2026 or earlier will continue to use the existing naming convention.