### PR TITLE
BCMOHAD-32077 Retry Mechanism Added for timeout exceptions for Health Ideas API

### DIFF
--- a/force-app/main/default/classes/HealthIdeasApiIntegration.cls
+++ b/force-app/main/default/classes/HealthIdeasApiIntegration.cls
@@ -152,42 +152,57 @@ public with sharing class HealthIdeasApiIntegration {
     public static IntegrationResult fetchHealthcareCosts(Id accountId, Date asOfDate, Date endDate, String requesterUserName) {
         
         IntegrationResult result = new IntegrationResult();
+        Integer retryCount = 0;
 
-        try {
-            Account acc = [SELECT Id, PHN__pc FROM Account WHERE Id = :accountId LIMIT 1];
-            
-            HttpResponse res = sendHealthIdeasRequest(requesterUserName, acc.PHN__pc, asOfDate, endDate);
-            
-            debugLog('Response Status Code: ' + res.getStatusCode());
-            debugLog('Response Status: ' + res.getStatus());
+        /*
+        Retry Mechanism for handling timeouts exceptions. 
+        If the callout fails due to a timeout, it will retry up to MAX_ATTEMPTS times.
+        */
+        while (retryCount < TPL_Constants.MAX_ATTEMPTS) {
+            try {
+                Account acc = [SELECT Id, PHN__pc FROM Account WHERE Id = :accountId LIMIT 1];
+                
+                HttpResponse res = sendHealthIdeasRequest(requesterUserName, acc.PHN__pc, asOfDate, endDate);
+                
+                debugLog('Response Status Code: ' + res.getStatusCode());
+                debugLog('Response Status: ' + res.getStatus());
 
-            if (res.getStatusCode() != 200) {
-                result.success = false;
-                result.errorMessage = TPL_Constants.ERROR_HEALTH_IDEAS_API_CALLOUT_FAILED + res.getStatus();
+                if (res.getStatusCode() != 200) {
+                    result.success = false;
+                    result.errorMessage = TPL_Constants.ERROR_HEALTH_IDEAS_API_CALLOUT_FAILED + res.getStatus();
+                    return result;
+                }
+
+                String responseBody = res.getBody();
+                
+                Map<String, Id> hccrecordTypeIds = getHealthcareCostRecordTypeIds();
+
+                HealthIdeasBatchPayload payload = parseHealthIdeasPayload(responseBody);
+                
+                refreshHealthcareCostRecords(
+                    accountId,
+                    asOfDate,
+                    payload,
+                    hccrecordTypeIds,
+                    result.messages
+                );
+                result.success = true;
                 return result;
+            } 
+            catch (Exception e) {
+                retryCount++;
+                if (!e.getMessage().contains(TPL_Constants.TIMEOUT_ERROR_MESSAGE) || retryCount >= TPL_Constants.MAX_ATTEMPTS) {
+                    result.success = false;
+                    result.errorMessage = e.getMessage();
+                    return result;
+                }
             }
-
-            String responseBody = res.getBody();
-            
-            Map<String, Id> hccrecordTypeIds = getHealthcareCostRecordTypeIds();
-
-            HealthIdeasBatchPayload payload = parseHealthIdeasPayload(responseBody);
-            
-            refreshHealthcareCostRecords(
-                accountId,
-                asOfDate,
-                payload,
-                hccrecordTypeIds,
-                result.messages
-            );
-            result.success = true;
-            return result;
-        } 
-        catch (Exception e) {
-            result.success = false;
-            result.errorMessage = e.getMessage();
-            return result;
         }
+
+        // Fallback return in case the retry loop exits without returning.
+        result.success = false;
+        result.errorMessage =  TPL_Constants.TIMEOUT_ERROR_MESSAGE;
+        return result;
     }
 
     /**
@@ -408,11 +423,13 @@ public with sharing class HealthIdeasApiIntegration {
 */
     public static HttpResponse sendHealthIdeasRequest(String requesterUserName, String phn, Date asOfDate, Date endDate) {
         
+        Integer timeValue = getTimeOutInteger(TPL_Constants.HI_BATCH_CONFIGURATION_RECORD_NAME, TPL_Constants.TIMEOUT_FIELD_NAME);
         HttpRequest req = new HttpRequest();
         req.setEndpoint('callout:HealthIdeas');
         req.setMethod('POST');
         req.setHeader('Content-Type', 'application/json');
-        req.setTimeout(120000);
+        req.setTimeout(timeValue);
+        system.debug(timeValue);
         req.setBody(JSON.serialize(new Map<String, Object>{
             'requester' => requesterUserName,
                 'personalHealthNumber' => phn,
@@ -721,6 +738,18 @@ public with sharing class HealthIdeasApiIntegration {
         );
         
         return truncatedValue;
+    }
+
+
+    // Get max timeout value set from the custom metadata records.
+    private static Integer getTimeOutInteger(String metadataRecordName, String fieldName) 
+    {
+        HealthIdeas_Batch_Configuration__mdt config =
+            HealthIdeas_Batch_Configuration__mdt.getInstance(metadataRecordName);
+
+        return config != null && config.get(fieldName) != null
+            ? Integer.valueOf(String.valueOf(config.get(fieldName)))
+            : TPL_Constants.DEFAULT_TIMEOUT_VALUE;
     }
 
     // Format date for UI Display

--- a/force-app/main/default/classes/HealthIdeasApiIntegrationTest.cls
+++ b/force-app/main/default/classes/HealthIdeasApiIntegrationTest.cls
@@ -8,18 +8,29 @@
 @IsTest
 private class HealthIdeasApiIntegrationTest {
     
+    private static Integer callCount = 0;
+    private class MockTimeoutException extends Exception {}
+    
     // Mock callout response for HealthIdeas API test scenarios.
     private class MockHttpResponseGenerator implements HttpCalloutMock {
         
         // Used to return a long hospitalization field value for failure/truncation scenarios.
         private Boolean forceHospitalizationDmlFailure;
+        private Boolean forceTimeout;
         
         MockHttpResponseGenerator() {
             this.forceHospitalizationDmlFailure = false;
+            this.forceTimeout = false;
         }
         
         MockHttpResponseGenerator(Boolean forceHospitalizationDmlFailure) {
             this.forceHospitalizationDmlFailure = forceHospitalizationDmlFailure;
+            this.forceTimeout = false;
+        }
+        
+        MockHttpResponseGenerator(Boolean forceTimeout, String timeoutFlag) {
+            this.forceTimeout = forceTimeout;
+            this.forceHospitalizationDmlFailure = false;
         }
         
         // Returns mock token and HealthIdeas API responses based on the request.
@@ -43,6 +54,11 @@ private class HealthIdeasApiIntegrationTest {
                 res.setBody('{"access_token":"fake-access-token","token_type":"Bearer","expires_in":3600}');
                 return res;
             }
+            
+            if (forceTimeout) {
+                callCount++;
+        		throw new MockTimeoutException(TPL_Constants.TIMEOUT_ERROR_MESSAGE);
+    		}
             
             String interventionCodesCci = forceHospitalizationDmlFailure
                 ? 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -724,5 +740,22 @@ private class HealthIdeasApiIntegrationTest {
         System.assertEquals(TPL_Constants.STATUS_COMPLETED, logRecord.Status__c);
         System.assertNotEquals(null, logRecord.Queueable_JobId__c);
         System.assertEquals(null, logRecord.Error_Message__c);
+    }
+    
+    // Covers retry mechanism for HealthIdeas API callouts that fail due to timeout exceptions.
+    @IsTest
+    static void testCallGetCost_MaxRetryTimeout() {
+        Account testAccount = getTestAccount();
+        callCount = 0;
+    
+        Test.setMock(HttpCalloutMock.class, new MockHttpResponseGenerator(true, 'timeout'));
+    
+        Test.startTest();
+        HealthIdeasApiIntegration.IntegrationResult result = HealthIdeasApiIntegration.getHealthcareCostsForAccountandSetDate(testAccount.Id, Date.newInstance(2025, 1, 1), false);
+        Test.stopTest();
+    
+        System.assertEquals(false, result.success);
+        System.assertEquals(TPL_Constants.MAX_ATTEMPTS,callCount, 'Expected the Health Ideas callout to be attempted MAX_ATTEMPTS times.');
+        System.assert(result.errorMessage.contains(TPL_Constants.TIMEOUT_ERROR_MESSAGE), 'Expected timeout error after maximum retry attempts.');
     }
 }

--- a/force-app/main/default/classes/TPL_Constants.cls
+++ b/force-app/main/default/classes/TPL_Constants.cls
@@ -10,6 +10,10 @@ public with sharing class TPL_Constants {
     public static final String STATUS_COMPLETED = 'Completed';
     public static final String STATUS_COMPLETED_WITH_ERRORS = 'Completed With Errors';
     public static final String STATUS_FAILED = 'Failed';
+    public static final Integer MAX_ATTEMPTS = 3;
+    public static final String TIMEOUT_ERROR_MESSAGE = 'Read timed out';
+    public static final String TIMEOUT_FIELD_NAME = 'Time_Out_Value_MilliSeconds__c';
+    public static final Integer DEFAULT_TIMEOUT_VALUE = 120000;
 
     public static final String CLASS_DOCX_GENERATOR_CONTROLLER = 'DocxGeneratorController';
     public static final String METHOD_GENERATE_DOCUMENT = 'generateDocument';

--- a/force-app/main/default/customMetadata/HealthIdeas_Batch_Configuration.BatchSize.md-meta.xml
+++ b/force-app/main/default/customMetadata/HealthIdeas_Batch_Configuration.BatchSize.md-meta.xml
@@ -8,6 +8,6 @@
     </values>
     <values>
         <field>Time_Out_Value_MilliSeconds__c</field>
-        <value xsi:type="xsd:string">120000</value>
+        <value xsi:type="xsd:string">40000</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/HealthIdeas_Batch_Configuration.BatchSize.md-meta.xml
+++ b/force-app/main/default/customMetadata/HealthIdeas_Batch_Configuration.BatchSize.md-meta.xml
@@ -6,4 +6,8 @@
         <field>Batch_Size__c</field>
         <value xsi:type="xsd:double">5.0</value>
     </values>
+    <values>
+        <field>Time_Out_Value_MilliSeconds__c</field>
+        <value xsi:type="xsd:string">120000</value>
+    </values>
 </CustomMetadata>

--- a/force-app/main/default/layouts/HealthIdeas_Batch_Configuration__mdt-HealthIdeas Batch Configuration Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/HealthIdeas_Batch_Configuration__mdt-HealthIdeas Batch Configuration Layout.layout-meta.xml
@@ -18,6 +18,10 @@
                 <behavior>Edit</behavior>
                 <field>Batch_Size__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Time_Out_Value_MilliSeconds__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/HealthIdeas_Batch_Configuration__mdt/fields/Time_Out_Value_MilliSeconds__c.field-meta.xml
+++ b/force-app/main/default/objects/HealthIdeas_Batch_Configuration__mdt/fields/Time_Out_Value_MilliSeconds__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Time_Out_Value_MilliSeconds__c</fullName>
+    <description>This field is used to set the timeout value, in milliseconds, for the Health Ideas API callout.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Time Out Value MilliSeconds</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
**Retry Mechanism for Health Ideas API**
Retry on timeout only: Retry the Health Ideas API call only when a timeout exception occurs.
Maximum 3 attempts: The API call can be attempted up to 3 times, including the initial request.
Stop after limit: If the timeout continues after the third attempt, stop retrying and return the failure.
Batch size back promoted from production.